### PR TITLE
LICENSE, IDE config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
-node_modules
 .nyc_output
-coverage
 .DS_store
-docker-compose.ovverride.yml
 .vscode
+.idea
+
+coverage
+
+docker-compose.ovverride.yml
+
+node_modules

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ And all these cases can be solved by AdminBro. By adding couple of lines of code
 
 ## License
 
-AdminBro is Copyright © 2018 SoftwareBrothers.co. It is free software, and may be redistributed under the terms specified in the [LICENSE](LICENSE) file.
+AdminBro is Copyright © 2018 SoftwareBrothers.co. It is free software, and may be redistributed under the terms specified in the [LICENSE](LICENSE.md) file.
 
 ## About SoftwareBrothers.co
 


### PR DESCRIPTION
This small PR fixes link to LICENSE file. There is a `LICENSE.md` file but link in `README.md` was to `LICENSE` (without `.md`).

I also added to `.gitignore` config files from popular JetBrains IDE (phpstorm, webstorm).