### PR TITLE
Fix ref editing sometimes losing correct state

### DIFF
--- a/src/frontend/components/property-type/reference/edit.tsx
+++ b/src/frontend/components/property-type/reference/edit.tsx
@@ -14,11 +14,8 @@ type SelectRecordEnhanced = SelectRecord & {
 }
 
 class Edit extends React.Component<CombinedProps> {
-  private selected: RecordJSON | null
-
   constructor(props: CombinedProps) {
     super(props)
-    this.selected = null
     this.loadOptions = this.loadOptions.bind(this)
     this.handleChange = this.handleChange.bind(this)
   }
@@ -26,7 +23,6 @@ class Edit extends React.Component<CombinedProps> {
   handleChange(selected: SelectRecordEnhanced): void {
     const { onChange, property } = this.props
     if (selected) {
-      this.selected = selected.record
       onChange(property.name, selected.value, selected.record)
     } else {
       onChange(property.name, '')
@@ -53,7 +49,7 @@ class Edit extends React.Component<CombinedProps> {
     const error = record.errors && record.errors[property.name]
 
     const reference = record.populated && record.populated[property.name]
-    let selectedOption = reference ? {
+    const selectedOption = reference ? {
       value: reference.id,
       label: reference.title,
     } : {
@@ -61,13 +57,6 @@ class Edit extends React.Component<CombinedProps> {
       label: '',
     }
     const styles = selectStyles(theme)
-
-    if (this.selected && record.params[property.name]) {
-      selectedOption = {
-        value: this.selected.id,
-        label: this.selected.title,
-      }
-    }
 
     return (
       <FormGroup error={!!error}>

--- a/src/frontend/hooks/use-record.tsx
+++ b/src/frontend/hooks/use-record.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react'
 import { AxiosResponse } from 'axios'
+import flat from 'flat'
 import ApiClient from '../utils/api-client'
 import RecordJSON from '../../backend/decorators/record-json.interface'
 import recordToFormData from '../components/actions/record-to-form-data'
@@ -117,6 +118,7 @@ export const useRecord = (
   const handleChange = useCallback((
     propertyOrRecord: RecordJSON | string,
     value?: any,
+    incomingRecord?: RecordJSON,
   ): void => {
     if (
       typeof value === 'undefined'
@@ -125,10 +127,30 @@ export const useRecord = (
     ) {
       setRecord(propertyOrRecord)
     } else {
-      setRecord(prev => ({
-        ...prev,
-        params: { ...prev.params, [propertyOrRecord as string]: value },
-      }))
+      setRecord((prev) => {
+        const key = propertyOrRecord as string
+        const inflated = flat.unflatten(prev.params) as Record<string, any>
+        let populatedModified = false
+        const populatedCopy = { ...prev.populated }
+        if (!value) {
+          delete inflated[key]
+          if (key in populatedCopy) {
+            delete populatedCopy[key]
+            populatedModified = true
+          }
+        } else {
+          inflated[key] = value
+          if (incomingRecord) {
+            populatedCopy[key] = incomingRecord
+            populatedModified = true
+          }
+        }
+        return {
+          ...prev,
+          params: flat.flatten(inflated),
+          populated: populatedModified ? populatedCopy : prev.populated,
+        }
+      })
     }
   }, [])
 


### PR DESCRIPTION
When updating refs in `src/frontend/components/property-type/reference/edit.tsx` the record loaded from the backend is passed to the `onChange` function. This is supposed to update `populated` field in the original record with the loaded one, so it's kept in sync with ID in the `params`. It however has no effect, since `onChange` function originates in `useRecord` hook and does not accept a third argument.

This PR fixes that by adding logic for updating `populated` field with passed record.

It fails on `lint` script but that's also failing on master and fixing it is outside of this PR's scope.