### PR TITLE
Export useSelectedRecords hook

### DIFF
--- a/src/frontend/hooks/index.ts
+++ b/src/frontend/hooks/index.ts
@@ -1,5 +1,6 @@
 export { default as useResourceEdit } from './use-resource-edit'
 export { default as useResourceNew } from './use-resource-new'
+export { default as useSelectedRecords } from './use-selected-records'
 export * from './use-notice'
 export * from './use-translation'
 export * from './use-record'


### PR DESCRIPTION
This is missing in the hooks export and is needed for custom `list` actions.