### PR TITLE
Fix reference selects being sometimes empty

### DIFF
--- a/src/frontend/components/property-type/reference/edit.tsx
+++ b/src/frontend/components/property-type/reference/edit.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import React, { FC, useState, useEffect } from 'react'
 import Select from 'react-select/lib/Async'
 import { withTheme, DefaultTheme } from 'styled-components'
 
@@ -13,15 +13,10 @@ type SelectRecordEnhanced = SelectRecord & {
   record: RecordJSON;
 }
 
-class Edit extends React.Component<CombinedProps> {
-  constructor(props: CombinedProps) {
-    super(props)
-    this.loadOptions = this.loadOptions.bind(this)
-    this.handleChange = this.handleChange.bind(this)
-  }
+const Edit: FC<CombinedProps> = (props) => {
+  const { onChange, property, record, theme } = props
 
-  handleChange(selected: SelectRecordEnhanced): void {
-    const { onChange, property } = this.props
+  const handleChange = (selected: SelectRecordEnhanced): void => {
     if (selected) {
       onChange(property.name, selected.value, selected.record)
     } else {
@@ -29,51 +24,67 @@ class Edit extends React.Component<CombinedProps> {
     }
   }
 
-  async loadOptions(inputValue: string): Promise<Array<SelectRecordEnhanced>> {
-    const { property } = this.props
+  const loadOptions = async (inputValue: string): Promise<SelectRecordEnhanced[]> => {
     const api = new ApiClient()
 
     const records = await api.searchRecords({
       resourceId: property.reference as string,
       query: inputValue,
     })
-    return records.map((record: RecordJSON) => ({
-      value: record.id,
-      label: record.title,
-      record,
+    return records.map((r: RecordJSON) => ({
+      value: r.id,
+      label: r.title,
+      record: r,
     }))
   }
+  const error = record.errors && record.errors[property.name]
 
-  render(): ReactNode {
-    const { property, record, theme } = this.props
-    const error = record.errors && record.errors[property.name]
-
-    const reference = record.populated && record.populated[property.name]
-    const selectedOption = reference ? {
-      value: reference.id,
-      label: reference.title,
-    } : {
-      value: '',
-      label: '',
-    }
-    const styles = selectStyles(theme)
-
-    return (
-      <FormGroup error={!!error}>
-        <Label htmlFor={property.name}>{property.label}</Label>
-        <Select
-          cacheOptions
-          value={selectedOption}
-          styles={styles}
-          defaultOptions
-          loadOptions={this.loadOptions}
-          onChange={this.handleChange}
-          isDisabled={property.isDisabled}
-        />
-        <FormMessage>{error && error.message}</FormMessage>
-      </FormGroup>
-    )
+  const selectedId = record?.params[property.name] as string | undefined
+  const [loadedRecord, setLoadedRecord] = useState<RecordJSON | undefined>()
+  const [loadingRecord, setLoadingRecord] = useState(0)
+  const selectedValue = record?.populated[property.name] ?? loadedRecord
+  const selectedOption = (selectedId && selectedValue) ? {
+    value: selectedValue.id,
+    label: selectedValue.title,
+  } : {
+    value: '',
+    label: '',
   }
+  const styles = selectStyles(theme)
+
+  useEffect(() => {
+    if (!selectedValue && selectedId) {
+      setLoadingRecord(c => c + 1)
+      const api = new ApiClient()
+      api.recordAction({
+        actionName: 'show',
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        resourceId: property.reference!,
+        recordId: selectedId,
+      }).then(({ data }: any) => {
+        setLoadedRecord(data.record)
+      }).finally(() => {
+        setLoadingRecord(c => c - 1)
+      })
+    }
+  }, [selectedValue, selectedId, property.reference])
+
+  return (
+    <FormGroup error={!!error}>
+      <Label htmlFor={property.name}>{property.label}</Label>
+      <Select
+        cacheOptions
+        value={selectedOption}
+        styles={styles}
+        defaultOptions
+        loadOptions={loadOptions}
+        onChange={handleChange}
+        isDisabled={property.isDisabled}
+        isLoading={loadingRecord}
+      />
+      <FormMessage>{error && error.message}</FormMessage>
+    </FormGroup>
+  )
 }
 
 export default withTheme(Edit)


### PR DESCRIPTION
Previously the `Edit` reference component only displayed the selected value when it was present in the `populated` field or was manually selected by the user. That is okay when editing fields or displaying them immediately after loading, assuming they're only one level deep. But AdminBro doesn't send `populated` fields for nested objects or objects in arrays. This means that for those properties the select displays no value even if it's actually correctly selected under the hood.

This PR converts `Edit` component to a function component and modifies it so that is uses the data loaded from the backend (which is already being used to fill the dropdown) to display currently selected option.