### PR TITLE
Make the input background white

### DIFF
--- a/src/frontend/components/design-system/atoms/input.tsx
+++ b/src/frontend/components/design-system/atoms/input.tsx
@@ -20,7 +20,7 @@ import { cssClass } from '../utils/css-class'
 export const InputCSS = css`
   box-sizing: border-box;
   color: ${({ theme }): string => theme.colors.grey80};
-  background: transparent;
+  background: ${({ theme }): string => theme.colors.white};
   border: 1px solid ${({ theme }): string => theme.colors.inputBorder};
   font-size: ${({ theme }): string => theme.fontSizes.default};
   line-height: ${({ theme }): string => theme.lineHeights.lg};


### PR DESCRIPTION
All other components have a white background, so I made regular inputs consistent. It's visible only when the background color of the custom `edit` action is different than white.