### PR TITLE
fixes #435 - search-action now respect custom sortBy in decorated.options

### DIFF
--- a/src/backend/actions/search-action.ts
+++ b/src/backend/actions/search-action.ts
@@ -35,10 +35,11 @@ const SearchAction: Action<SearchActionResponse> = {
     const filters = queryString ? { [titlePropertyName]: queryString } : {}
     const filter = new Filter(filters, resource)
 
+    const sortBy = decorated.options && decorated.options.sort && decorated.options.sort.sortBy || titlePropertyName
     const records = await resource.find(filter, {
       limit: 50,
       sort: {
-        sortBy: titlePropertyName,
+        sortBy,
         direction: 'asc',
       },
     })


### PR DESCRIPTION
search-action now respect custom sortBy in decorated.options. ListAction.handler my also need to be updated. I'm not sure and don't know the code base well enough.

Please note these two tests failed on a windows system before and after the change.

  163 passing (2s)
  2 failing

  1) generateUserComponentEntry
       adds components to the entry file:
     AssertionError: expected 'AdminBro.UserComponents = {}\nimport Component5 from \'spec/fixtures/example-component\'\nAdminBro.UserComponents.Component5 = Component5' to contain 'import Component5 from \'spec\\fixtures\\example-component\'\nAdminBro.UserComponents.Component5 = Component5'
      at Context.<anonymous> (src\backend\bundler\generate-user-component-entry.spec.js:38:31)
      at processImmediate (internal/timers.js:456:21)

  2) Router
       returns development bundle by default:
     AssertionError: expected 'C:\\Users\\Michael Hobbs\\WebstormProjects\\admin-bro\\src\\frontend\\assets\\scripts\\app-bundle.development.js' to include 'scripts/app-bundle.development.js'
      at Context.<anonymous> (src\backend\router.spec.ts:17:46)
      at processImmediate (internal/timers.js:456:21)

