### PR TITLE
Display breadcrumbs on actions without record

### DIFF
--- a/src/frontend/components/app/breadcrumbs.tsx
+++ b/src/frontend/components/app/breadcrumbs.tsx
@@ -65,7 +65,7 @@ const Breadcrumbs: React.FC<Props> = (props) => {
       <BreadcrumbLink to={resource.href ? resource.href : '/'} className={record ? 'is-active' : ''}>
         {resource.name}
       </BreadcrumbLink>
-      {action && record ? (<BreadcrumbLink to="#">{action.label}</BreadcrumbLink>) : null}
+      { action && action.name !== 'list' && <BreadcrumbLink to="#">{action.label}</BreadcrumbLink>}
     </Box>
   )
 }


### PR DESCRIPTION
The last breadcrumb wasn't displayed on `new` action as well as on custom actions defined by user.