### PR TITLE
Show dropdown for year selection

### DIFF
--- a/src/frontend/components/property-type/datetime/edit.tsx
+++ b/src/frontend/components/property-type/datetime/edit.tsx
@@ -21,6 +21,7 @@ const Edit: React.FC<EditPropertyProps> = (props) => {
         value={value}
         disabled={property.isDisabled}
         onChange={(data: string): void => onChange(property.name, data)}
+        showYearDropdown
       />
       <FormMessage>{error && error.message}</FormMessage>
     </FormGroup>


### PR DESCRIPTION
Add [`showYearDropdown`](https://reactdatepicker.com/#example-year-dropdown) option to [react-datepicker](https://www.npmjs.com/package/react-datepicker)

It helps the usability of the date component to select a date in the past, or in the future (without resorting to editing the input value directly)