### PR TITLE
fix: show date (only) format without time

### DIFF
--- a/example-app/cypress/integration/external-employees/create-external-employee.spec.js
+++ b/example-app/cypress/integration/external-employees/create-external-employee.spec.js
@@ -20,4 +20,11 @@ context('resources/ExternalEmployees/actions/new', () => {
         expect(contentValue).to.eq('"*"')
       })
   })
+
+  it('format date (only) in datepicker without time', () => {
+    const hiredAt = new Date().toISOString().slice(0, 10)
+    cy.get('[data-testid="property-edit-hiredAt"] button').click()
+    cy.get('.react-datepicker__day--today').click()
+    cy.get('[data-testid="property-edit-hiredAt"] input').should('have.value', hiredAt)
+  })
 })

--- a/example-app/models/externalemployees.js
+++ b/example-app/models/externalemployees.js
@@ -24,7 +24,7 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.BOOLEAN,
     },
     hiredAt: {
-      type: DataTypes.DATE,
+      type: DataTypes.DATEONLY,
     },
     role: {
       type: DataTypes.ENUM(['admin', 'guest']),

--- a/src/frontend/components/design-system/molecules/date-picker.tsx
+++ b/src/frontend/components/design-system/molecules/date-picker.tsx
@@ -141,7 +141,7 @@ const formatTime = (date: Date): string => `${pad(date.getHours())}:${pad(date.g
 
 const formatDateTime = (date: Date): string => `${formatDate(date)} ${formatTime(date)}`
 
-const formatType = (date: Date, propertyType: string): string => {
+const formatType = (date: Date, propertyType: string | undefined): string => {
   if (propertyType === 'date') {
     return formatDate(date)
   }

--- a/src/frontend/components/design-system/molecules/date-picker.tsx
+++ b/src/frontend/components/design-system/molecules/date-picker.tsx
@@ -123,6 +123,10 @@ export type DatePickerProps = {
    */
   onChange: (date: string) => void;
   /**
+   * property type, date or datetime
+   */
+  propertyType?: string;
+  /**
    * Indicates if year dropdown should be seen
    */
   showYearDropdown?: boolean;
@@ -130,8 +134,19 @@ export type DatePickerProps = {
 
 const pad = (n: number): string => (n < 10 ? `0${n.toString()}` : n.toString())
 
-const format = (date: Date): string => `${date.getFullYear()}-${pad(date.getMonth() + 1)
-}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`
+const formatDate = (date: Date): string => `${date.getFullYear()}-${pad(date.getMonth() + 1)
+}-${pad(date.getDate())}`
+
+const formatTime = (date: Date): string => `${pad(date.getHours())}:${pad(date.getMinutes())}`
+
+const formatDateTime = (date: Date): string => `${formatDate(date)} ${formatTime(date)}`
+
+const formatType = (date: Date, propertyType: string): string => {
+  if (propertyType === 'date') {
+    return formatDate(date)
+  }
+  return formatDateTime(date)
+}
 
 /**
  * Component responsible for showing dates. It is a wrapper to
@@ -149,7 +164,7 @@ const format = (date: Date): string => `${date.getFullYear()}-${pad(date.getMont
  * )
  */
 export const DatePicker: React.FC<DatePickerProps> = (props) => {
-  const { value, onChange, disabled, ...other } = props
+  const { value, onChange, disabled, propertyType, ...other } = props
 
   const [hidden, setHidden] = useState(true)
 
@@ -162,12 +177,12 @@ export const DatePicker: React.FC<DatePickerProps> = (props) => {
       dateValue = new Date(dateNum)
     }
   } else if (value && value.constructor.name === 'Date') {
-    stringValue = format(value as Date)
+    stringValue = formatType(value as Date, propertyType)
   }
 
   const onDatePickerChange = (date: Date): void => {
     if (!disabled) {
-      onChange(format(date))
+      onChange(formatType(date, propertyType))
     }
   }
 

--- a/src/frontend/components/property-type/datetime/edit.tsx
+++ b/src/frontend/components/property-type/datetime/edit.tsx
@@ -21,6 +21,7 @@ const Edit: React.FC<EditPropertyProps> = (props) => {
         value={value}
         disabled={property.isDisabled}
         onChange={(data: string): void => onChange(property.name, data)}
+        propertyType={property.type}
         showYearDropdown
       />
       <FormMessage>{error && error.message}</FormMessage>


### PR DESCRIPTION
Pass the `property.type` (as `propertyType` prop) to the `DatePicker` component to show the relevant format for date (only) types