### PR TITLE
fix: datepicker style overwrite for year selection

### DIFF
--- a/src/frontend/components/design-system/molecules/date-picker.tsx
+++ b/src/frontend/components/design-system/molecules/date-picker.tsx
@@ -28,6 +28,7 @@ const StyledDatePicker = styled(InputGroup)`
 
   & .react-datepicker__navigation--next {
     border-left-color: ${({ theme }): string => theme.colors.primary60};
+    top: 16px;
   }
   & .react-datepicker__navigation--next:hover {
     border-left-color: ${({ theme }): string => theme.colors.primary100};
@@ -35,6 +36,7 @@ const StyledDatePicker = styled(InputGroup)`
 
   & .react-datepicker__navigation--previous {
     border-right-color: ${({ theme }): string => theme.colors.primary60};
+    top: 16px;
   }
   & .react-datepicker__navigation--previous:hover {
     border-right-color: ${({ theme }): string => theme.colors.primary100};
@@ -42,7 +44,10 @@ const StyledDatePicker = styled(InputGroup)`
 
   & .react-datepicker__navigation {
     outline: none;
-    top: 16px;
+  }
+
+  & .react-datepicker__year-read-view--down-arrow {
+    top: 5px;
   }
 
   & .react-datepicker__header {


### PR DESCRIPTION
After https://github.com/SoftwareBrothers/admin-bro/pull/512 I noticed everything is pushed down a few pixels in the year dropdown, due to the style override. Therefore the upcoming year navigation is overlapping the list of years

Before:
<img width="293" alt="Screenshot 2020-07-10 at 17 17 58" src="https://user-images.githubusercontent.com/1508563/87176046-6bc13900-c2d1-11ea-9371-2fb0c07c5825.png">

After:
<img width="299" alt="Screenshot 2020-07-10 at 17 20 53" src="https://user-images.githubusercontent.com/1508563/87176233-bba00000-c2d1-11ea-8270-937a4ffc467a.png">





