### PR TITLE
fix: return underlying resource name in getResourceName

### DIFF
--- a/src/backend/decorators/resource-decorator.ts
+++ b/src/backend/decorators/resource-decorator.ts
@@ -155,7 +155,7 @@ class ResourceDecorator {
    * @return {string} resource name
    */
   getResourceName(): string {
-    return this._admin.translateLabel(this.id(), this.id())
+    return this._admin.translateLabel(this.id(), this._resource.name())
   }
 
   /**


### PR DESCRIPTION
Fix https://github.com/SoftwareBrothers/admin-bro/issues/471

The resource [`getResourceName`](https://github.com/SoftwareBrothers/admin-bro/blob/6551b2b60c05f0f6c330bfd4a9d872573b2f9d13/src/backend/decorators/resource-decorator.ts#L157-L159) method currently returns the resource id.

In both [sequelizejs](https://github.com/SoftwareBrothers/admin-bro-sequelizejs/blob/74776c4a04a09022e29610b0729bc2b7694b0b0c/src/resource.js#L38-L44) and [mongoose](https://github.com/SoftwareBrothers/admin-bro-mongoose/blob/master/src/resource.js#L53-L59) adapters, `id` and `name` are essentially returning the same value (i.e. tableName). 

But if an adapter was returning different values, which one should the `getResourceName` be using? I guess the name makes more sense.

Current side effects of this change is when using multiple resources using the same table. In this case, the change will result in the name (tableName) being returned for all the resources (instead of the `id`, which must be different). 

This is not necessarily ideal. But since we can still change the name using the locale>translations options in AdminBroOptions I don't see that as an issue.

@KrishnaPG suggested using the resource name in `translateLabel` instead of the `id` for the key
https://github.com/SoftwareBrothers/admin-bro/issues/471#issuecomment-660566595

The issue I can see with that suggestion would be not being able to customise the name when using multiple resources from the same table (since the name would most likely be the same).

Open to more suggestions



