### PR TITLE
reference type clear selected value

### DIFF
--- a/src/frontend/components/property-type/reference/edit.tsx
+++ b/src/frontend/components/property-type/reference/edit.tsx
@@ -47,6 +47,7 @@ const Edit: FC<CombinedProps> = (props) => {
   const selectedId = record?.params[property.name] as string | undefined
   const [loadedRecord, setLoadedRecord] = useState<RecordJSON | undefined>()
   const [loadingRecord, setLoadingRecord] = useState(0)
+  const isClearable = !property.isRequired
   const selectedValue = record?.populated[property.name] ?? loadedRecord
   const selectedOption = (selectedId && selectedValue) ? {
     value: selectedValue.id,
@@ -90,6 +91,7 @@ const Edit: FC<CombinedProps> = (props) => {
         onChange={handleChange}
         isDisabled={property.isDisabled}
         isLoading={loadingRecord}
+        isClearable={isClearable}
       />
       <FormMessage>{error?.message}</FormMessage>
     </FormGroup>


### PR DESCRIPTION
#515 
this version's reference type is just search and select only.
so add [`isClearable`](https://react-select.com/props) to the [react-select](https://github.com/JedWatson/react-select) [`Select`](https://github.com/SoftwareBrothers/admin-bro/blob/26c637829c5576bb7a221294343f6a78d8da2831/src/frontend/components/property-type/reference/edit.tsx#L79-L88) in reference's edit component.
then developer want setting up null using [this solution](https://github.com/SoftwareBrothers/admin-bro/issues/342#issuecomment-621442262)

![image](https://user-images.githubusercontent.com/5378062/87979888-b6cb1f80-cb0d-11ea-99c7-69c91d215025.png)
![image](https://user-images.githubusercontent.com/5378062/87979897-b9c61000-cb0d-11ea-820e-b4d8e370d58e.png)
