### PR TITLE
docs: typo

### DIFF
--- a/src/backend/actions/action.interface.ts
+++ b/src/backend/actions/action.interface.ts
@@ -556,7 +556,7 @@ export default interface Action <T extends ActionResponse> {
 
   /**
    * The max width of action HTML container.
-   * You can put here an actual size in px or an array wf widths, where different values
+   * You can put here an actual size in px or an array of widths, where different values
    * will be responsible for different breakpoints.
    * It is directly passed to action's wrapping {@link Box} component, to its `width` property.
    *


### PR DESCRIPTION
Fix a typo in "array wf widths" where wf should be of