### PR TITLE
feat: accept extra props on DatePicker to pass down

### DIFF
--- a/src/frontend/components/design-system/molecules/date-picker.tsx
+++ b/src/frontend/components/design-system/molecules/date-picker.tsx
@@ -126,6 +126,10 @@ export type DatePickerProps = {
    * Indicates if year dropdown should be seen
    */
   showYearDropdown?: boolean;
+  /**
+   * Any custom props to pass down to the ReactDatePicker
+   */
+  [key: string]: any;
 }
 
 const pad = (n: number): string => (n < 10 ? `0${n.toString()}` : n.toString())

--- a/src/frontend/components/design-system/molecules/date-picker.tsx
+++ b/src/frontend/components/design-system/molecules/date-picker.tsx
@@ -123,10 +123,6 @@ export type DatePickerProps = {
    */
   onChange: (date: string) => void;
   /**
-   * Indicates if year dropdown should be seen
-   */
-  showYearDropdown?: boolean;
-  /**
    * Any custom props to pass down to the ReactDatePicker
    */
   [key: string]: any;

--- a/src/frontend/components/property-type/datetime/edit.tsx
+++ b/src/frontend/components/property-type/datetime/edit.tsx
@@ -21,7 +21,7 @@ const Edit: React.FC<EditPropertyProps> = (props) => {
         value={value}
         disabled={property.isDisabled}
         onChange={(data: string): void => onChange(property.name, data)}
-        showYearDropdown
+        {...property.custom}
       />
       <FormMessage>{error && error.message}</FormMessage>
     </FormGroup>


### PR DESCRIPTION
Currently the [`DatePicker`](https://github.com/SoftwareBrothers/admin-bro/blob/62bad1d3d83401a700dd6d5dac4c65c7307da87d/src/frontend/components/design-system/molecules/date-picker.tsx#L112-L129) component type definition doesn't allow custom props to be passed down, even though [the code](https://github.com/SoftwareBrothers/admin-bro/blob/62bad1d3d83401a700dd6d5dac4c65c7307da87d/src/frontend/components/design-system/molecules/date-picker.tsx#L198) would allow it.

From what I understand (correct me if I'm wrong here), simply adding this to the arguments type definition:
```
[key: string]: any;
```
would allow to pass props to the `DatePicker` component, which would then be passed to the [`react-datepicker`](https://reactdatepicker.com/)

The reason for doing this is simple, if someone wants to customise the datepicker component, currently they have to duplicate the whole [DatePicker](https://github.com/SoftwareBrothers/admin-bro/blob/62bad1d3d83401a700dd6d5dac4c65c7307da87d/src/frontend/components/design-system/molecules/date-picker.tsx) component. Ideally, with this change, it would allow to customise only the [`Edit`](https://github.com/SoftwareBrothers/admin-bro/blob/62bad1d3d83401a700dd6d5dac4c65c7307da87d/src/frontend/components/property-type/datetime/edit.tsx) component, like this:

```
import React from 'react'

import { DatePicker, Label, FormGroup, FormMessage } from 'admin-bro'

const Edit = (props) => {
  const { property, onChange, record } = props
  const value = (record.params && record.params[property.name]) || ''
  const error = record.errors && record.errors[property.name]

  return (
    <FormGroup error={!!error}>
      <Label
        htmlFor={property.name}
        required={property.isRequired}
      >
        {property.label}
      </Label>
      <DatePicker
        value={value}
        disabled={property.isDisabled}
        onChange={(data) => onChange(property.name, data)}
        showYearPicker
        dateFormat="yyyy"
      />
      <FormMessage>{error && error.message}</FormMessage>
    </FormGroup>
  )
}

export default Edit
```

This adds `showYearPicker` and `dateFormat="yyyy"` for example.

An even better way to do this would be to accept custom properties on the original [`Edit`](https://github.com/SoftwareBrothers/admin-bro/blob/62bad1d3d83401a700dd6d5dac4c65c7307da87d/src/frontend/components/property-type/datetime/edit.tsx) component. Something like this perhaps:

```
      <DatePicker
        value={value}
        disabled={property.isDisabled}
        onChange={(data: string): void => onChange(property.name, data)}
        showYearDropdown
        {...property.custom}
      />
```

Let me know the preferred approach, and I will amend the code or send another PR if necessary
