### PR TITLE
fix: load reference object inside onChange callback when value updated

### DIFF
--- a/src/frontend/components/property-type/reference/edit.tsx
+++ b/src/frontend/components/property-type/reference/edit.tsx
@@ -58,7 +58,7 @@ const Edit: FC<CombinedProps> = (props) => {
   const styles = selectStyles(theme)
 
   useEffect(() => {
-    if (!selectedValue && selectedId) {
+    if (selectedId && (!selectedValue || selectedValue.id != selectedId)) {
       setLoadingRecord(c => c + 1)
       const api = new ApiClient()
       api.recordAction({


### PR DESCRIPTION
I was attempting to change the reference property value on a record using `onChange` (passed from props) on an edit form. For some reason the field value is updating, but not the selected value in the react-select component.

The weird part is, it was updating correctly after calling `onChange` once. But subsequent calls seems to fail to update the react-select selected value. I found this is due to the check on `selectedValue`, which is being set after the first call.

Adding a comparison on record.id seems to fix the issue.

