### PR TITLE
feat: add step, min and max props for number properties

### DIFF
--- a/src/frontend/components/property-type/default-type/edit.tsx
+++ b/src/frontend/components/property-type/default-type/edit.tsx
@@ -10,6 +10,26 @@ import usePrevious from '../../../utils/usePrevious'
 
 type CombinedProps = EditPropertyProps & {theme: DefaultTheme}
 
+const getNumberProps = (type, options) : object => {
+  if (type !== 'number' && type !== 'float') {
+    return {}
+  }
+  let min = options.min
+  let max = options.max
+  if (typeof min === 'undefined') {
+    min = type === 'number' ? Number.MIN_SAFE_INTEGER : Number.MIN_VALUE
+  }
+  if (typeof max === 'undefined') {
+    max = type === 'number' ? Number.MAX_SAFE_INTEGER : Number.MAX_VALUE
+  }
+  return {
+    type: 'number',
+    min,
+    max,
+    step: options.step || 1,
+  }
+}
+
 const Edit: FC<CombinedProps> = (props) => {
   const { property, record } = props
   const error = record.errors?.[property.name]
@@ -51,6 +71,7 @@ const TextEdit: FC<CombinedProps> = (props) => {
   const { property, record, onChange } = props
   const propValue = record.params?.[property.name] ?? ''
   const [value, setValue] = useState(propValue)
+  const numberProps = getNumberProps(property.type, property.custom)
 
   const previous = usePrevious(propValue)
   useEffect(() => {
@@ -68,6 +89,7 @@ const TextEdit: FC<CombinedProps> = (props) => {
       onBlur={() => onChange(property.name, value)}
       value={value}
       disabled={property.isDisabled}
+      {...numberProps}
     />
   )
 }

--- a/src/frontend/components/property-type/default-type/filter.tsx
+++ b/src/frontend/components/property-type/default-type/filter.tsx
@@ -23,10 +23,31 @@ class Filter extends React.PureComponent<FilterPropertyProps & ThemeProps<Defaul
     onChange(property.name, value)
   }
 
+  getNumberProps(type, options): object {
+    if (type !== 'number' && type !== 'float') {
+      return {}
+    }
+    let min = options.min
+    let max = options.max
+    if (typeof min === 'undefined') {
+      min = type === 'number' ? Number.MIN_SAFE_INTEGER : Number.MIN_VALUE
+    }
+    if (typeof max === 'undefined') {
+      max = type === 'number' ? Number.MAX_SAFE_INTEGER : Number.MAX_VALUE
+    }
+    return {
+      type: 'number',
+      min,
+      max,
+      step: options.step || 1,
+    }
+  }
+
   renderInput(): ReactNode {
     const { property, filter, theme } = this.props
     const filterKey = `filter-${property.name}`
     const value = filter[property.name] || ''
+    const numberProps = this.getNumberProps(property.type, property.custom)
     if (property.availableValues) {
       const selected = property.availableValues.find(av => av.value === value)
       return (
@@ -44,6 +65,7 @@ class Filter extends React.PureComponent<FilterPropertyProps & ThemeProps<Defaul
         name={filterKey}
         onChange={this.handleInputChange}
         value={value}
+        {...numberProps}
       />
     )
   }


### PR DESCRIPTION
# What this PR does
- Adds `step`, `min` and `max` props when a property is of type `number` or `float`.
  - `step` defaults to `1`
  - `min`/`max` default to `Number.MIN_SAFE_INTEGER`/`Number.MAX_SAFE_INTEGER` or `Number.MIN_VALUE`/`Number.MAX_VALUE`  depending on the type being `number` or `float`
- Properties are pulled from `custom` object in property declaration.