### PR TITLE
fix: initialize i18n only if its not already, extend otherwise

### DIFF
--- a/src/admin-bro.ts
+++ b/src/admin-bro.ts
@@ -175,16 +175,19 @@ class AdminBro {
       translations: combineTranslations(en.translations, this.options.locale?.translations),
       language: this.options.locale?.language || en.language,
     }
-
-    i18n.init({
-      lng: this.locale.language,
-      initImmediate: false, // loads translations immediately
-      resources: {
-        [this.locale.language]: {
-          translation: this.locale.translations,
+    if (i18n.isInitialized) {
+      i18n.addResourceBundle(this.locale.language, 'translation', this.locale.translations)
+    } else {
+      i18n.init({
+        lng: this.locale.language,
+        initImmediate: false, // loads translations immediately
+        resources: {
+          [this.locale.language]: {
+            translation: this.locale.translations,
+          },
         },
-      },
-    })
+      })
+    }
 
     // mixin translate functions to AdminBro instance so users will be able to
     // call adminBro.translateMessage(...)


### PR DESCRIPTION
fixes #592 
you still need to put initializing admin-bro into the success callback of i18n to work together:
```js
const loadAdminBro = () => {
  const { adminBro, adminRouter } = admin()
  app.use(adminBro.options.rootPath, adminMiddleware, adminRouter)
  app.use('/admin', adminMiddleware, adminController)
}

i18next.init({...}, (err, t) => {
  loadAdminBro()
})
```
but then works like a charm :D