### PR TITLE
fix: [#601] Sidebar state is now stored in Redux Store

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -73,6 +73,12 @@ module.exports = {
                 'spaced-comment': 'off'
             }
         },
+        {
+            files: ['example-app/**/*.js'],
+            rules: {
+                'no-var-requires': off
+            },
+        }
     ],
     globals: {
         'expect': true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -76,7 +76,7 @@ module.exports = {
         {
             files: ['example-app/**/*.js'],
             rules: {
-                'no-var-requires': off
+                'no-var-requires': 'off',
             },
         }
     ],

--- a/example-app/package.json
+++ b/example-app/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "main": "index.js",
   "author": "Wojciech Krysiak",
-  "type": "module",
   "license": "MIT",
   "scripts": {
     "dev": "nodemon --ext '.js,.mjs' --watch ../lib --watch ./ --ignore 'cypress/**/*.js'",

--- a/src/frontend/components/app/sidebar/sidebar-resource.tsx
+++ b/src/frontend/components/app/sidebar/sidebar-resource.tsx
@@ -1,12 +1,11 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 import { RouteComponentProps } from 'react-router'
 import { Text } from '@admin-bro/design-system'
 
 import ResourceJSON from '../../../../backend/decorators/resource-json.interface'
 import SidebarLink from './styled/sidebar-link.styled'
-import { useSidebar } from './../../../hooks/use-sidebar'
+import { useSidebar } from '../../../hooks/use-sidebar'
 
 type Props = {
   resource: ResourceJSON;
@@ -22,7 +21,7 @@ const SidebarResource: React.FC<Props & RouteComponentProps> = (props) => {
     return null
   }
   return (
-    <SidebarLink to={resource.href} onClick={() => toggleSidebar()} isActive={isActive} data-testid="sidebar-resource-link">
+    <SidebarLink to={resource.href} onClick={(): void => toggleSidebar()} isActive={isActive} data-testid="sidebar-resource-link">
       <Text as="span">{resource.name}</Text>
     </SidebarLink>
   )

--- a/src/frontend/components/app/sidebar/sidebar-resource.tsx
+++ b/src/frontend/components/app/sidebar/sidebar-resource.tsx
@@ -1,17 +1,20 @@
 import React from 'react'
+import { useSelector } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 import { RouteComponentProps } from 'react-router'
 import { Text } from '@admin-bro/design-system'
 
 import ResourceJSON from '../../../../backend/decorators/resource-json.interface'
 import SidebarLink from './styled/sidebar-link.styled'
-
+import { useSidebar } from './../../../hooks/use-sidebar'
 
 type Props = {
   resource: ResourceJSON;
 }
 
 const SidebarResource: React.FC<Props & RouteComponentProps> = (props) => {
+  const { toggleSidebar } = useSidebar()
+
   const { resource } = props
   const regExp = new RegExp(`/resources/${resource.id}($|/)`)
   const isActive = (match, location): boolean => !!location.pathname.match(regExp)
@@ -19,7 +22,7 @@ const SidebarResource: React.FC<Props & RouteComponentProps> = (props) => {
     return null
   }
   return (
-    <SidebarLink to={resource.href} isActive={isActive} data-testid="sidebar-resource-link">
+    <SidebarLink to={resource.href} onClick={() => toggleSidebar()} isActive={isActive} data-testid="sidebar-resource-link">
       <Text as="span">{resource.name}</Text>
     </SidebarLink>
   )

--- a/src/frontend/components/app/sidebar/sidebar.tsx
+++ b/src/frontend/components/app/sidebar/sidebar.tsx
@@ -17,9 +17,8 @@ type Props = {
 const Sidebar: React.FC<Props> = (props) => {
   const { isVisible } = props
   const [branding, resources, pages] = useSelector((state: ReduxState) => [
-    state.branding, state.resources, state.pages,
+    state.branding, state.resources, state.pages
   ])
-
   const { translateLabel } = useTranslation()
 
   return (

--- a/src/frontend/components/app/sidebar/sidebar.tsx
+++ b/src/frontend/components/app/sidebar/sidebar.tsx
@@ -17,7 +17,7 @@ type Props = {
 const Sidebar: React.FC<Props> = (props) => {
   const { isVisible } = props
   const [branding, resources, pages] = useSelector((state: ReduxState) => [
-    state.branding, state.resources, state.pages
+    state.branding, state.resources, state.pages,
   ])
   const { translateLabel } = useTranslation()
 

--- a/src/frontend/components/application.tsx
+++ b/src/frontend/components/application.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-children-prop */
-import React, { useState } from 'react'
+import React from 'react'
+import { useSelector } from 'react-redux'
 import { Switch, Route } from 'react-router-dom'
 import { createGlobalStyle } from 'styled-components'
 import { Box, Overlay } from '@admin-bro/design-system'
@@ -8,10 +9,13 @@ import ViewHelpers from '../../backend/utils/view-helpers'
 import Sidebar from './app/sidebar/sidebar'
 import TopBar from './app/top-bar'
 import Notice from './app/notice'
+import { ReduxState } from './../store/store'
+import { useSidebar } from './../hooks/use-sidebar'
 
 import {
   Dashboard, ResourceAction, RecordAction, Page, BulkAction, Resource,
 } from './routes'
+import isMobileDevice from '../utils/isMobileDevice'
 
 const GlobalStyle = createGlobalStyle`
   html, body, #app {
@@ -24,7 +28,12 @@ const GlobalStyle = createGlobalStyle`
 `
 
 const App: React.FC = () => {
-  const [sidebarVisible, toggleSidebar] = useState(false)
+  const [sidebar] = useSelector((state: ReduxState) => [
+    state.sidebar
+  ])
+
+  const { toggleSidebar } = useSidebar()
+
   const h = new ViewHelpers()
 
   const resourceId = ':resourceId'
@@ -42,14 +51,15 @@ const App: React.FC = () => {
     <React.Fragment>
       <GlobalStyle />
       <Box height="100%" flex>
-        {sidebarVisible ? (
+        {sidebar.isOpen ? (
           <Overlay
-            onClick={(): void => toggleSidebar(!sidebarVisible)}
+            hidden={isMobileDevice() ? false : true}
+            onClick={(): void => toggleSidebar()}
           />
         ) : null}
-        <Sidebar isVisible={sidebarVisible} />
+        <Sidebar isVisible={sidebar.isOpen} />
         <Box flex flexGrow={1} flexDirection="column" overflowY="auto" bg="bg">
-          <TopBar toggleSidebar={(): void => toggleSidebar(!sidebarVisible)} />
+          <TopBar toggleSidebar={(): void => toggleSidebar()} />
           <Box position="absolute" top={0}>
             <Notice />
           </Box>

--- a/src/frontend/components/application.tsx
+++ b/src/frontend/components/application.tsx
@@ -9,8 +9,8 @@ import ViewHelpers from '../../backend/utils/view-helpers'
 import Sidebar from './app/sidebar/sidebar'
 import TopBar from './app/top-bar'
 import Notice from './app/notice'
-import { ReduxState } from './../store/store'
-import { useSidebar } from './../hooks/use-sidebar'
+import { ReduxState } from '../store/store'
+import { useSidebar } from '../hooks/use-sidebar'
 
 import {
   Dashboard, ResourceAction, RecordAction, Page, BulkAction, Resource,
@@ -29,7 +29,7 @@ const GlobalStyle = createGlobalStyle`
 
 const App: React.FC = () => {
   const [sidebar] = useSelector((state: ReduxState) => [
-    state.sidebar
+    state.sidebar,
   ])
 
   const { toggleSidebar } = useSidebar()
@@ -53,7 +53,7 @@ const App: React.FC = () => {
       <Box height="100%" flex>
         {sidebar.isOpen ? (
           <Overlay
-            hidden={isMobileDevice() ? false : true}
+            hidden={!isMobileDevice()}
             onClick={(): void => toggleSidebar()}
           />
         ) : null}

--- a/src/frontend/hooks/use-sidebar.ts
+++ b/src/frontend/hooks/use-sidebar.ts
@@ -1,12 +1,12 @@
 import { useDispatch } from 'react-redux'
-import { toggleSidebar } from '../store/actions/sidebar'
+import toggleSidebar from '../store/actions/sidebar'
 
 /**
  * @memberof useSidebar
  * @alias Sidebar
  */
 export interface Sidebar {
-  toggleSidebar: () => any
+  toggleSidebar: () => void;
 }
 
 /**
@@ -29,7 +29,7 @@ export interface Sidebar {
 export const useSidebar = (): Sidebar => {
   const dispatch = useDispatch()
   return {
-    toggleSidebar() { dispatch(toggleSidebar()) }
+    toggleSidebar(): void { dispatch(toggleSidebar()) },
   }
 }
 

--- a/src/frontend/hooks/use-sidebar.ts
+++ b/src/frontend/hooks/use-sidebar.ts
@@ -1,0 +1,36 @@
+import { useDispatch } from 'react-redux'
+import { toggleSidebar } from '../store/actions/sidebar'
+
+/**
+ * @memberof useSidebar
+ * @alias Sidebar
+ */
+export interface Sidebar {
+  toggleSidebar: () => any
+}
+
+/**
+ * Hook which allows you to manipulate the sidebar.
+ *
+ * ```usage
+ * import { useSidebar } from 'admin-bro'
+ *
+ * const myComponent = () => {
+ *   const { toggleSidebar } = useSidebar()
+ *   render (
+ *     <Button onClick={() => toggleSidebar()}>Sidebar Open/close</Button>
+ *   )
+ * }
+ * ```
+ *
+ * @component
+ * @subcategory Hooks
+ */
+export const useSidebar = (): Sidebar => {
+  const dispatch = useDispatch()
+  return {
+    toggleSidebar() { dispatch(toggleSidebar()) }
+  }
+}
+
+export default useSidebar

--- a/src/frontend/store/actions/sidebar.ts
+++ b/src/frontend/store/actions/sidebar.ts
@@ -1,9 +1,11 @@
-import { SidebarMessageInState } from "../store";
+import { SidebarMessageInState } from '../store'
 
-export const toggleSidebar = (): {
+const toggleSidebar = (): {
     type: string;
     data: SidebarMessageInState;
 } => ({
-    type: 'SIDEBAR_TOGGLE',
-    data: {},
+  type: 'SIDEBAR_TOGGLE',
+  data: {},
 })
+
+export default toggleSidebar

--- a/src/frontend/store/actions/sidebar.ts
+++ b/src/frontend/store/actions/sidebar.ts
@@ -1,0 +1,9 @@
+import { SidebarMessageInState } from "../store";
+
+export const toggleSidebar = (): {
+    type: string;
+    data: SidebarMessageInState;
+} => ({
+    type: 'SIDEBAR_TOGGLE',
+    data: {},
+})

--- a/src/frontend/store/store.ts
+++ b/src/frontend/store/store.ts
@@ -258,6 +258,22 @@ const noticesReducer = (state: Array<NoticeMessageInState> = [], action: {
   }
 }
 
+
+export type SidebarMessageInState = {}
+export type SidebarStore = {
+  isOpen: boolean
+}
+const sidebarReducer = (state = { isOpen: false }, action: {
+  type: string;
+  data: SidebarMessageInState;
+}): SidebarStore => {
+  switch (action.type) {
+  case 'SIDEBAR_TOGGLE':
+    return {...action.data, isOpen: !state.isOpen}
+  default: return state
+  }
+}
+
 export type ReduxState = {
   resources: Array<ResourceJSON>;
   branding: BrandingOptions;
@@ -269,6 +285,7 @@ export type ReduxState = {
   versions: VersionProps;
   pages: Array<PageJSON>;
   locale: Locale;
+  sidebar: SidebarStore;
 }
 
 const reducer = combineReducers<ReduxState>({
@@ -282,6 +299,7 @@ const reducer = combineReducers<ReduxState>({
   versions: versionsReducer,
   pages: pagesReducer,
   locale: localesReducer,
+  sidebar: sidebarReducer
 })
 
 export default (initialState = {}) => createStore(reducer, initialState)

--- a/src/frontend/store/store.ts
+++ b/src/frontend/store/store.ts
@@ -260,16 +260,14 @@ const noticesReducer = (state: Array<NoticeMessageInState> = [], action: {
 
 
 export type SidebarMessageInState = {}
-export type SidebarStore = {
-  isOpen: boolean
-}
+export type SidebarStore = { isOpen: boolean }
 const sidebarReducer = (state = { isOpen: false }, action: {
   type: string;
   data: SidebarMessageInState;
 }): SidebarStore => {
   switch (action.type) {
   case 'SIDEBAR_TOGGLE':
-    return {...action.data, isOpen: !state.isOpen}
+    return { ...action.data, isOpen: !state.isOpen }
   default: return state
   }
 }
@@ -299,7 +297,7 @@ const reducer = combineReducers<ReduxState>({
   versions: versionsReducer,
   pages: pagesReducer,
   locale: localesReducer,
-  sidebar: sidebarReducer
+  sidebar: sidebarReducer,
 })
 
 export default (initialState = {}) => createStore(reducer, initialState)

--- a/src/frontend/utils/isMobileDevice.ts
+++ b/src/frontend/utils/isMobileDevice.ts
@@ -1,7 +1,8 @@
-export default function isMobileDevice() {
-    try {
-        return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-    } catch (e) {
-        return false;
-    }
+export default function isMobileDevice(): boolean {
+  try {
+    // eslint-disable-next-line no-undef
+    return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
+  } catch (e) {
+    return false
+  }
 }

--- a/src/frontend/utils/isMobileDevice.ts
+++ b/src/frontend/utils/isMobileDevice.ts
@@ -1,0 +1,7 @@
+export default function isMobileDevice() {
+    try {
+        return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+    } catch (e) {
+        return false;
+    }
+}


### PR DESCRIPTION
Fix for #601.

Sidebar state is now controlled on Redux State.
Created a React Hook for Sidebar that can be called anywhere