### PR TITLE
fix: fix BaseRecord.param(path) returning [null]

### DIFF
--- a/src/backend/adapters/record/base-record.ts
+++ b/src/backend/adapters/record/base-record.ts
@@ -53,7 +53,11 @@ class BaseRecord {
    * @deprecated in favour of {@link BaseRecord#get} and {@link BaseRecord#set} methods
    */
   param(path: string): any {
-    return flat.get(this.params, path)
+    const paramValue = flat.get(this.params, path)
+    if (Array.isArray(paramValue) && paramValue.every(v => !v)) {
+      return null
+    }
+    return paramValue
   }
 
   /**


### PR DESCRIPTION
This is a fix to: https://github.com/SoftwareBrothers/admin-bro/issues/634
However, I've no idea why `flat.get(...)` would return `[null]`.