### PR TITLE
fix: array manipulaton in deeply nested properties

### DIFF
--- a/example-app/src/employees/employee.entity.js
+++ b/example-app/src/employees/employee.entity.js
@@ -1,5 +1,33 @@
 const mongoose = require('mongoose')
 
+const Skill = new mongoose.Schema({
+  name: String,
+  level: {
+    type: String,
+    enum: ['junior', 'middle', 'senior'],
+  },
+  Profession: {
+    type: mongoose.SchemaTypes.ObjectId,
+    ref: 'Profession',
+  },
+})
+
+const OtherSchema = new mongoose.Schema({
+  name: String,
+  arrayed: {
+    type: [Skill],
+  },
+})
+
+const Skills = new mongoose.Schema({
+  softShills: [{
+    type: Skill,
+  }],
+  hardSkills: [{
+    type: Skill,
+  }],
+})
+
 const EmployeeSchema = new mongoose.Schema({
   name: {
     type: String,
@@ -16,10 +44,21 @@ const EmployeeSchema = new mongoose.Schema({
     type: mongoose.SchemaTypes.ObjectId,
     ref: 'Company',
   },
+  interests: {
+    type: [String],
+  },
   professions: [{
     type: mongoose.SchemaTypes.ObjectId,
     ref: 'Profession',
   }],
+
+  Skills: {
+    type: Skills,
+  },
+
+  otherField: {
+    type: [OtherSchema],
+  },
 })
 
 const Employee = mongoose.model('Employee', EmployeeSchema)

--- a/src/backend/adapters/record/base-record.ts
+++ b/src/backend/adapters/record/base-record.ts
@@ -1,4 +1,4 @@
-import { flat } from '../../../utils/flat'
+import { flat, GetOptions } from '../../../utils/flat'
 import { ParamsType } from './params.type'
 import BaseResource from '../resource/base-resource'
 import ValidationError, { RecordError, PropertyErrors } from '../../utils/errors/validation-error'
@@ -69,11 +69,12 @@ class BaseRecord {
    *
    * @param {string} [propertyPath]     path for the property. If not set function returns an entire
    *                                    unflatten object
+   * @param {GetOptions} [options]
    * @return {any}                      unflatten data under given path
    * @new in version 3.3
    */
-  get(propertyPath?: string): any {
-    return flat.get(this.params, propertyPath)
+  get(propertyPath?: string, options?: GetOptions): any {
+    return flat.get(this.params, propertyPath, options)
   }
 
   /**
@@ -96,9 +97,23 @@ class BaseRecord {
    * @param   {string}  prefix
    *
    * @return  {object | undefined}
+   * @deprecated in favour of {@link selectParams}
    */
   namespaceParams(prefix: string): Record<string, any> | void {
     return flat.selectParams(this.params, prefix)
+  }
+
+  /**
+   * Returns object containing all params keys starting with prefix
+   *
+   * @param   {string}  prefix
+   * @param {GetOptions} [options]
+   *
+   * @return  {object | undefined}
+   * @new in version 3.3
+   */
+  selectParams(prefix: string, options?: GetOptions): Record<string, any> | void {
+    return flat.selectParams(this.params, prefix, options)
   }
 
   /**

--- a/src/backend/controllers/api-controller.spec.js
+++ b/src/backend/controllers/api-controller.spec.js
@@ -38,6 +38,7 @@ describe('ApiController', function () {
         resourceActions: () => [this.action],
         recordActions: () => [this.action],
         recordsDecorator: records => records,
+        getFlattenProperties: this.sinon.stub().returns([property]),
         id: this.resourceName,
       }),
       find: this.sinon.stub().returns([]),

--- a/src/backend/decorators/property/property-decorator.spec.ts
+++ b/src/backend/decorators/property/property-decorator.spec.ts
@@ -193,7 +193,7 @@ describe('PropertyDecorator', () => {
         'isArray',
         'custom',
         'resourceId',
-        'path',
+        'propertyPath',
         'isRequired',
         'isVirtual',
         'props',

--- a/src/backend/decorators/property/property-decorator.ts
+++ b/src/backend/decorators/property/property-decorator.ts
@@ -3,7 +3,7 @@ import PropertyOptions from './property-options.interface'
 import BaseResource from '../../adapters/resource/base-resource'
 import BaseProperty, { PropertyType } from '../../adapters/property/base-property'
 import ResourceDecorator from '../resource/resource-decorator'
-import { PropertyPlace, PropertyJSON } from '../../../frontend/interfaces'
+import { PropertyPlace, BasePropertyJSON } from '../../../frontend/interfaces'
 import { overrideFromOptions } from './utils'
 
 /**
@@ -23,7 +23,7 @@ class PropertyDecorator {
    * This path serves as a key in {@link PropertyOptions} to identify which
    * property has to be updated
    */
-  public path: string
+  public propertyPath: string
 
   /**
    * Indicates if given property has been created in AdminBro and hasn't been returned by the
@@ -63,7 +63,7 @@ class PropertyDecorator {
     this.property = property
     this._admin = admin
     this._resource = resource
-    this.path = path || property.name()
+    this.propertyPath = path || property.name()
     this.isVirtual = !!isVirtual
     this.virtualSubProperties = []
 
@@ -123,7 +123,7 @@ class PropertyDecorator {
    * @return  {string}
    */
   label(): string {
-    return this._admin.translateProperty(this.path, this._resource.id())
+    return this._admin.translateProperty(this.propertyPath, this._resource.id())
   }
 
   /**
@@ -153,7 +153,7 @@ class PropertyDecorator {
       return values.map(val => ({
         value: val,
         label: this._admin.translateProperty(
-          `${this.path}.${val}`,
+          `${this.propertyPath}.${val}`,
           this._resource.id(),
           { defaultValue: val },
         ),
@@ -246,7 +246,7 @@ class PropertyDecorator {
    *
    * @return {PropertyJSON}
    */
-  toJSON(where?: PropertyPlace): PropertyJSON {
+  toJSON(where?: PropertyPlace): BasePropertyJSON {
     return {
       isTitle: this.isTitle(),
       isId: this.isId(),
@@ -256,7 +256,7 @@ class PropertyDecorator {
       isRequired: this.isRequired(),
       availableValues: this.availableValues(),
       name: this.name(),
-      path: this.path,
+      propertyPath: this.propertyPath,
       isDisabled: this.isDisabled(),
       label: this.label(),
       type: this.type(),
@@ -280,7 +280,7 @@ class PropertyDecorator {
    */
   subProperties(): Array<PropertyDecorator> {
     const dbSubProperties = this.property.subProperties().map((subProperty) => {
-      const path = `${this.path}.${subProperty.name()}`
+      const path = `${this.propertyPath}.${subProperty.name()}`
       const decorated = new PropertyDecorator({
         property: subProperty,
         admin: this._admin,
@@ -301,14 +301,14 @@ class PropertyDecorator {
    * Returns PropertyOptions passed by the user for a subProperty. Furthermore
    * it changes property name to the nested property key.
    *
-   * @param   {BaseProperty}     subProperty
+   * @param   {String}     propertyPath
    * @return  {PropertyOptions}
    * @private
    */
-  private getOptionsForSubProperty(path: string): PropertyOptions {
+  private getOptionsForSubProperty(propertyPath: string): PropertyOptions {
     const propertyOptions = (this._resource.options || {}).properties || {}
     return {
-      ...propertyOptions[path],
+      ...propertyOptions[propertyPath],
     }
   }
 }

--- a/src/backend/decorators/resource/resource-decorator.spec.ts
+++ b/src/backend/decorators/resource/resource-decorator.spec.ts
@@ -159,7 +159,7 @@ describe('ResourceDecorator', function () {
       const decoratedProperty = decorator.getPropertyByKey(path) as PropertyDecorator
 
       expect(decoratedProperty).to.be.an.instanceof(PropertyDecorator)
-      expect(decoratedProperty.path).to.eq(path)
+      expect(decoratedProperty.propertyPath).to.eq(path)
     })
 
     it('returns nested property under 2 level nested mixed', function () {
@@ -171,7 +171,7 @@ describe('ResourceDecorator', function () {
       const decoratedProperty = decorator.getPropertyByKey(path) as PropertyDecorator
 
       expect(decoratedProperty).to.be.an.instanceof(PropertyDecorator)
-      expect(decoratedProperty.path).to.eq(path)
+      expect(decoratedProperty.propertyPath).to.eq(path)
     })
 
     it('returns property when it is an array', function () {
@@ -182,7 +182,7 @@ describe('ResourceDecorator', function () {
       const decoratedProperty = decorator.getPropertyByKey(path) as PropertyDecorator
 
       expect(decoratedProperty).to.be.an.instanceof(PropertyDecorator)
-      expect(decoratedProperty.path).to.eq(arrayProperty.path())
+      expect(decoratedProperty.propertyPath).to.eq(arrayProperty.path())
     })
 
     it('returns property when it is an nested array', function () {
@@ -196,7 +196,7 @@ describe('ResourceDecorator', function () {
       const decoratedProperty = decorator.getPropertyByKey(path) as PropertyDecorator
 
       expect(decoratedProperty).to.be.an.instanceof(PropertyDecorator)
-      expect(decoratedProperty.path).to.eq([arrayProperty.path(), nested1Property.path()].join('.'))
+      expect(decoratedProperty.propertyPath).to.eq([arrayProperty.path(), nested1Property.path()].join('.'))
     })
   })
 

--- a/src/backend/decorators/resource/resource-decorator.ts
+++ b/src/backend/decorators/resource/resource-decorator.ts
@@ -7,7 +7,7 @@ import AdminBro from '../../../admin-bro'
 
 import { ResourceOptions } from './resource-options.interface'
 import { CurrentAdmin } from '../../../current-admin.interface'
-import { ResourceJSON, PropertyJSON, PropertyPlace } from '../../../frontend/interfaces'
+import { ResourceJSON, PropertyPlace } from '../../../frontend/interfaces'
 import {
   decorateActions,
   decorateProperties,
@@ -86,7 +86,7 @@ class ResourceDecorator {
     this.options.properties = this.options.properties || {}
 
     /**
-     * List of all decorated properties
+     * List of all decorated root properties
      * @type {Array<PropertyDecorator>}
      */
     this.properties = decorateProperties(resource, admin, this)
@@ -179,14 +179,17 @@ class ResourceDecorator {
     return properties
   }
 
-  getFlattenProperties(): Record<string, PropertyJSON> {
+  /**
+   * Returns all the properties with corresponding subProperties in one object.
+   */
+  getFlattenProperties(): Record<string, PropertyDecorator> {
     return Object.keys(this.properties).reduce((memo, propertyName) => {
       const property = this.properties[propertyName]
 
       const subProperties = flatSubProperties(property)
       return {
         ...memo,
-        [propertyName]: property.toJSON(),
+        [propertyName]: property,
         ...subProperties,
       }
     }, {})
@@ -294,6 +297,12 @@ class ResourceDecorator {
    * @return  {ResourceJSON}
    */
   toJSON(currentAdmin?: CurrentAdmin): ResourceJSON {
+    const flattenProperties = this.getFlattenProperties()
+    const flattenPropertiesJSON = Object.keys(flattenProperties).reduce((memo, key) => ({
+      ...memo,
+      [key]: flattenProperties[key].toJSON(),
+    }), {})
+
     return {
       id: this.id(),
       name: this.getResourceName(),
@@ -302,7 +311,7 @@ class ResourceDecorator {
       titleProperty: this.titleProperty().toJSON(),
       resourceActions: this.resourceActions(currentAdmin).map(ra => ra.toJSON(currentAdmin)),
       actions: Object.values(this.actions).map(action => action.toJSON(currentAdmin)),
-      properties: this.getFlattenProperties(),
+      properties: flattenPropertiesJSON,
       listProperties: this.getProperties({
         where: 'list', max: DEFAULT_MAX_COLUMNS_IN_LIST,
       }).map(property => property.toJSON('list')),

--- a/src/backend/decorators/resource/utils/decorate-properties.ts
+++ b/src/backend/decorators/resource/utils/decorate-properties.ts
@@ -74,7 +74,7 @@ const organizeNestedProperties = (
     // reverse because we start by by finding from the longest path
     // and removes itself. (skips arrays)
     // changes 'root.nested.0.nested1' to [root.nested', 'root']
-    const parts = pathToParts(property.path, { skipArrayIndexes: true }).reverse().splice(1)
+    const parts = pathToParts(property.propertyPath, { skipArrayIndexes: true }).reverse().splice(1)
     if (parts.length) {
       const mixedPropertyPath = parts.find(part => (
         properties[part] && properties[part].type() === 'mixed'

--- a/src/backend/decorators/resource/utils/find-sub-property.ts
+++ b/src/backend/decorators/resource/utils/find-sub-property.ts
@@ -16,9 +16,9 @@ export const findSubProperty = (
 ): PropertyDecorator | null => {
   const subProperties = rootProperty.subProperties()
   const foundPath = pathParts.find(path => (
-    subProperties.find(supProperty => supProperty.path === path)))
+    subProperties.find(supProperty => supProperty.propertyPath === path)))
   if (foundPath) {
-    const subProperty = subProperties.find(supProperty => supProperty.path === foundPath)
+    const subProperty = subProperties.find(supProperty => supProperty.propertyPath === foundPath)
     if (subProperty && foundPath !== pathParts[pathParts.length - 1]) {
       // if foundPath is not the last (full) path - checkout recursively all subProperties
       return findSubProperty(pathParts, subProperty)

--- a/src/backend/decorators/resource/utils/flat-sub-properties.ts
+++ b/src/backend/decorators/resource/utils/flat-sub-properties.ts
@@ -18,7 +18,7 @@ export const flatSubProperties = (
 ): Record<string, PropertyJSON> => (
   rootProperty.subProperties().reduce((subMemo, subProperty) => ({
     ...subMemo,
-    [subProperty.path]: subProperty.toJSON(),
+    [subProperty.propertyPath]: subProperty.toJSON(),
     ...flatSubProperties(subProperty),
   }), {})
 )

--- a/src/backend/decorators/resource/utils/flat-sub-properties.ts
+++ b/src/backend/decorators/resource/utils/flat-sub-properties.ts
@@ -1,5 +1,4 @@
 import PropertyDecorator from '../../property/property-decorator'
-import { PropertyJSON } from '../../../../frontend/interfaces'
 
 /**
  * Bu default all subProperties are nested as an array in root Property. This is easy for
@@ -15,10 +14,10 @@ import { PropertyJSON } from '../../../../frontend/interfaces'
  */
 export const flatSubProperties = (
   rootProperty: PropertyDecorator,
-): Record<string, PropertyJSON> => (
+): Record<string, PropertyDecorator> => (
   rootProperty.subProperties().reduce((subMemo, subProperty) => ({
     ...subMemo,
-    [subProperty.propertyPath]: subProperty.toJSON(),
+    [subProperty.propertyPath]: subProperty,
     ...flatSubProperties(subProperty),
   }), {})
 )

--- a/src/backend/utils/populator/populate-property.spec.ts
+++ b/src/backend/utils/populator/populate-property.spec.ts
@@ -25,7 +25,7 @@ describe('populateProperty', () => {
     property.resource.returns(resourceDecorator as unknown as ResourceDecorator)
     property.reference.returns(referenceResource as unknown as BaseResource)
     property.property = { reference: 'someRawReference' } as unknown as BaseProperty
-    property.path = path
+    property.propertyPath = path
   })
 
   afterEach(() => {

--- a/src/backend/utils/populator/populate-property.spec.ts
+++ b/src/backend/utils/populator/populate-property.spec.ts
@@ -39,6 +39,7 @@ describe('populateProperty', () => {
   context('2 same records with reference key', () => {
     beforeEach(async () => {
       record.get.returns(userId)
+      record.selectParams.returns({ [path]: userId })
       userRecord.id.returns(userId)
       referenceResource.findMany.resolves([userRecord])
 

--- a/src/backend/utils/populator/populate-property.ts
+++ b/src/backend/utils/populator/populate-property.ts
@@ -29,7 +29,7 @@ export async function populateProperty(
   if (!referencedResource) {
     throw new Error([
       `There is no reference resource named: "${property.property.reference}"`,
-      `for property: "${decoratedResource.id()}.properties.${property.path}"`,
+      `for property: "${decoratedResource.id()}.properties.${property.propertyPath}"`,
     ].join('\n'))
   }
 
@@ -41,7 +41,7 @@ export async function populateProperty(
   // first, we create externalIdsMap[1] = null where 1 is userId. This make keys unique and assign
   // nulls to each of them
   const externalIdsMap = records.reduce((memo, baseRecord) => {
-    const foreignKeyValue = baseRecord.get(property.path)
+    const foreignKeyValue = baseRecord.get(property.propertyPath)
     // array properties returns arrays so we have to take the all into consideration
     if (Array.isArray(foreignKeyValue) && property.isArray()) {
       return foreignKeyValue.reduce((arrayMemo, valueInArray) => ({
@@ -85,17 +85,17 @@ export async function populateProperty(
   return records.map((record) => {
     // we set record.populated['userId'] = externalIdsMap[record.param('userId)]
     // but this can also be an array - we have to check it
-    const foreignKeyValue = record.get(property.path)
+    const foreignKeyValue = record.get(property.propertyPath)
 
     if (Array.isArray(foreignKeyValue)) {
       foreignKeyValue.forEach((foreignKeyValueItem, index) => {
         record.populate(
-          [property.path, index].join(DELIMITER),
+          [property.propertyPath, index].join(DELIMITER),
           externalIdsMap[foreignKeyValueItem],
         )
       })
     } else if (typeof foreignKeyValue === 'string' || typeof foreignKeyValue === 'number') {
-      record.populate(property.path, externalIdsMap[foreignKeyValue])
+      record.populate(property.propertyPath, externalIdsMap[foreignKeyValue])
     }
 
     return record

--- a/src/backend/utils/populator/populate-property.ts
+++ b/src/backend/utils/populator/populate-property.ts
@@ -1,4 +1,3 @@
-import { DELIMITER } from '../../../utils/flat/constants'
 import { BaseRecord } from '../../adapters'
 import PropertyDecorator from '../../decorators/property/property-decorator'
 
@@ -13,6 +12,7 @@ const isValueSearchable = (value: any): value is string | number => (
  * @param {Array<BaseRecord>} records   array of records to populate
  * @param {PropertyDecorator} property  Decorator for the reference property to populate
  * @private
+ * @hide
  */
 export async function populateProperty(
   records: Array<BaseRecord> | null,
@@ -41,9 +41,13 @@ export async function populateProperty(
   // first, we create externalIdsMap[1] = null where 1 is userId. This make keys unique and assign
   // nulls to each of them
   const externalIdsMap = records.reduce((memo, baseRecord) => {
-    const foreignKeyValue = baseRecord.get(property.propertyPath)
-    // array properties returns arrays so we have to take the all into consideration
-    if (Array.isArray(foreignKeyValue) && property.isArray()) {
+    const foreignKeyValue = baseRecord.get(property.propertyPath, { includeAllSiblings: true })
+    // 2 kind of properties returning arrays
+    //   - the one with the array type
+    //   - the one which are nested within an arrays (fetched by the help of
+    //   the options { includeAllSiblings: true } in baseRecord.get().
+    // so we have to take it all into consideration
+    if (Array.isArray(foreignKeyValue)) {
       return foreignKeyValue.reduce((arrayMemo, valueInArray) => ({
         ...arrayMemo,
         ...(isValueSearchable(valueInArray) ? { [valueInArray]: valueInArray } : {}),
@@ -61,7 +65,7 @@ export async function populateProperty(
 
   const uniqueExternalIds = Object.values<string | number>(externalIdsMap)
 
-  // when no record has `userId` filled = return input `records`
+  // when no record has reference filled (ie `userId`) = return input `records`
   if (!uniqueExternalIds.length) {
     return records
   }
@@ -69,13 +73,15 @@ export async function populateProperty(
   // now find all referenced records: all users
   const referenceRecords = await referencedResource.findMany(uniqueExternalIds)
 
-  //
+  // even if record has value for this reference - it might not have the referenced record itself
+  // this happens quite often in mongodb where there are no constrains on the database
   if (!referenceRecords || !referenceRecords.length) {
     return records
   }
 
   // now assign these users to `externalIdsMap` instead of the empty object we had. To speed up
-  // assigning them to record#populated we will do in the next step
+  // assigning them to record#populated we will do in the next step by calling:
+  // `externalIdsMap[id]` to get populated record instead of finding them in an array
   referenceRecords.forEach((referenceRecord) => {
     // example: externalIds[1] = { ...userRecord } | null (if not found)
     const foreignKeyValue = referenceRecord.id()
@@ -83,20 +89,22 @@ export async function populateProperty(
   })
 
   return records.map((record) => {
-    // we set record.populated['userId'] = externalIdsMap[record.param('userId)]
-    // but this can also be an array - we have to check it
-    const foreignKeyValue = record.get(property.propertyPath)
+    // first lets extract all the existing params from the given record which belongs to given
+    // property. Usually it will be just one element, but for arrays and items nested inside arrays
+    // there will be more like this for array:
+    // {
+    //    'professions.0': '5f7462621eb3495ea0f0edd7',
+    //    'professions.1': '5f7462621eb3495ea0f0edd6',
+    // }
+    const referenceParams = record.selectParams(property.propertyPath, {
+      includeAllSiblings: true,
+    }) || {}
 
-    if (Array.isArray(foreignKeyValue)) {
-      foreignKeyValue.forEach((foreignKeyValueItem, index) => {
-        record.populate(
-          [property.propertyPath, index].join(DELIMITER),
-          externalIdsMap[foreignKeyValueItem],
-        )
-      })
-    } else if (typeof foreignKeyValue === 'string' || typeof foreignKeyValue === 'number') {
-      record.populate(property.propertyPath, externalIdsMap[foreignKeyValue])
-    }
+    // next we copy the exact params structure to record.populated changing the value with found
+    // record
+    Object.entries(referenceParams).forEach(([path, foreignKeyValueItem]) => {
+      record.populate(path, externalIdsMap[foreignKeyValueItem])
+    })
 
     return record
   })

--- a/src/backend/utils/populator/populator.ts
+++ b/src/backend/utils/populator/populator.ts
@@ -13,7 +13,7 @@ export async function populator(
     return records
   }
   const resourceDecorator = records[0].resource.decorate()
-  const allProperties = Object.values(resourceDecorator.properties)
+  const allProperties = Object.values(resourceDecorator.getFlattenProperties())
 
   const references = allProperties.filter(p => !!p.reference())
 

--- a/src/frontend/components/actions/edit.tsx
+++ b/src/frontend/components/actions/edit.tsx
@@ -62,7 +62,7 @@ const Edit: FC<ActionProps> = (props) => {
           />
         )) : resource.editProperties.map(property => (
           <PropertyType
-            key={property.path}
+            key={property.propertyPath}
             where="edit"
             onChange={handleChange}
             property={property}

--- a/src/frontend/components/actions/new.tsx
+++ b/src/frontend/components/actions/new.tsx
@@ -66,7 +66,7 @@ const New: FC<ActionProps> = (props) => {
           />
         )) : resource.editProperties.map(property => (
           <PropertyType
-            key={property.path}
+            key={property.propertyPath}
             where="edit"
             onChange={handleChange}
             property={property}

--- a/src/frontend/components/actions/show.tsx
+++ b/src/frontend/components/actions/show.tsx
@@ -30,7 +30,7 @@ const Show: React.FC<ActionProps> = (props) => {
         />
       )) : properties.map(property => (
         <PropertyType
-          key={property.path}
+          key={property.propertyPath}
           where="show"
           property={property}
           resource={resource}

--- a/src/frontend/components/actions/utils/layout-element-renderer.tsx
+++ b/src/frontend/components/actions/utils/layout-element-renderer.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import * as DesignSystem from '@admin-bro/design-system'
 import { ActionProps } from '../action.props'
 import PropertyType from '../../property-type'
-import { PropertyPlace } from '../../../interfaces/property-json.interface'
+import { PropertyPlace } from '../../../interfaces/property-json/property-json.interface'
 import { ParsedLayoutElement } from '../../../../backend/utils/layout-element-parser'
 import { BasePropertyProps } from '../../property-type/base-property-props'
 
@@ -47,9 +47,9 @@ export const LayoutElementRenderer: React.FC<Props> = (props) => {
   return (
     <Component {...other as any}>
       {properties.map(property => (
-        <DesignSystem.Box flexGrow={1} key={property.path}>
+        <DesignSystem.Box flexGrow={1} key={property.propertyPath}>
           <PropertyType
-            key={property.path}
+            key={property.propertyPath}
             where={where}
             property={property}
             resource={resource}

--- a/src/frontend/components/app/filter-drawer.tsx
+++ b/src/frontend/components/app/filter-drawer.tsx
@@ -105,7 +105,7 @@ export const FilterDrawer: React.FC<FilterProps> = (props) => {
         <Box my="x3">
           {properties.map(property => (
             <PropertyType
-              key={property.path}
+              key={property.propertyPath}
               where="filter"
               onChange={handleChange}
               property={property}

--- a/src/frontend/components/app/records-table/property-header.tsx
+++ b/src/frontend/components/app/records-table/property-header.tsx
@@ -1,15 +1,15 @@
 import React from 'react'
 import { TableCell } from '@admin-bro/design-system'
 
-import { PropertyJSON } from '../../../interfaces'
+import { BasePropertyJSON } from '../../../interfaces'
 import SortLink from '../sort-link'
 
 export type PropertyHeaderProps = {
-  property: PropertyJSON;
+  property: BasePropertyJSON;
   /**
    * Property which should be treated as main property.
    */
-  titleProperty: PropertyJSON;
+  titleProperty: BasePropertyJSON;
   /**
    * currently selected direction. Either 'asc' or 'desc'.
    */
@@ -25,7 +25,7 @@ export type PropertyHeaderProps = {
 export const PropertyHeader: React.FC<PropertyHeaderProps> = (props) => {
   const { property, titleProperty, display } = props
 
-  const isMain = property.path === titleProperty.path
+  const isMain = property.propertyPath === titleProperty.propertyPath
 
   return (
     <TableCell

--- a/src/frontend/components/app/records-table/record-in-list.tsx
+++ b/src/frontend/components/app/records-table/record-in-list.tsx
@@ -102,15 +102,15 @@ export const RecordInList: React.FC<RecordInListProps> = (props) => {
       {resource.listProperties.map(property => (
         <TableCell
           style={{ cursor: 'pointer' }}
-          key={property.path}
-          data-property-name={property.path}
+          key={property.propertyPath}
+          data-property-name={property.propertyPath}
           display={display(property.isTitle)}
         >
           {isLoading ? (
             <Placeholder style={{ height: 14 }} />
           ) : (
             <PropertyType
-              key={property.path}
+              key={property.propertyPath}
               where="list"
               property={property}
               resource={resource}

--- a/src/frontend/components/app/records-table/records-table-header.tsx
+++ b/src/frontend/components/app/records-table/records-table-header.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { CheckBox, TableHead, TableRow, TableCell } from '@admin-bro/design-system'
 
 import PropertyHeader from './property-header'
-import { PropertyJSON } from '../../../interfaces'
+import { BasePropertyJSON } from '../../../interfaces'
 import { display } from './utils/display'
 
 /**
@@ -13,11 +13,11 @@ export type RecordsTableHeaderProps = {
   /**
    * Property which should be treated as a Title Property
    */
-  titleProperty: PropertyJSON;
+  titleProperty: BasePropertyJSON;
   /**
    * All properties which should be presented
    */
-  properties: Array<PropertyJSON>;
+  properties: Array<BasePropertyJSON>;
   /**
    * Name of the property which should be marked as currently sorted by
    */
@@ -100,7 +100,7 @@ export const RecordsTableHeader: React.FC<RecordsTableHeaderProps> = (props) => 
         {properties.map(property => (
           <PropertyHeader
             display={display(property.isTitle)}
-            key={property.path}
+            key={property.propertyPath}
             titleProperty={titleProperty}
             property={property}
             sortBy={sortBy}

--- a/src/frontend/components/app/sort-link.tsx
+++ b/src/frontend/components/app/sort-link.tsx
@@ -4,11 +4,11 @@ import { NavLink, withRouter } from 'react-router-dom'
 import { RouteComponentProps } from 'react-router'
 import { Icon, cssClass } from '@admin-bro/design-system'
 
-import { PropertyJSON } from '../../interfaces'
+import { BasePropertyJSON } from '../../interfaces'
 
 
 export type SortLinkProps = {
-  property: PropertyJSON;
+  property: BasePropertyJSON;
   direction?: 'asc' | 'desc';
   sortBy?: string;
 }
@@ -21,7 +21,7 @@ class SortLink extends React.PureComponent<SortLinkProps & RouteComponentProps> 
 
   isActive(): boolean {
     const { sortBy, property } = this.props
-    return sortBy === property.path
+    return sortBy === property.propertyPath
   }
 
   render(): ReactNode {
@@ -31,7 +31,7 @@ class SortLink extends React.PureComponent<SortLinkProps & RouteComponentProps> 
     const sortedByIcon = `Caret${direction === 'asc' ? 'Up' : 'Down'}`
 
     query.set('direction', oppositeDirection)
-    query.set('sortBy', property.path)
+    query.set('sortBy', property.propertyPath)
 
     return (
       <NavLink to={{ search: query.toString() }} className={cssClass('SortLink')}>

--- a/src/frontend/components/property-type/array/convert-to-sub-property.tsx
+++ b/src/frontend/components/property-type/array/convert-to-sub-property.tsx
@@ -1,0 +1,21 @@
+import { DELIMITER } from '../../../../utils/flat/constants'
+import { PropertyJSON } from '../../../interfaces'
+
+/**
+ * Converts property: PropertyJSON from an array to a sub-property for an actual item in the array
+ * It change path that it has index inside along with the label. Futhermore flat isArray is removed
+ * ,because it was already handled, so that itemRenderer can render property as a regular one
+ *
+ * @param {PropertyJSON}  arrayProperty property with path set to an root Array type property,
+ * @param {Number}        index         index under which sub-property should be placed
+ * @private
+ * @hide
+ */
+export const convertToSubProperty = (arrayProperty: PropertyJSON, index: number): PropertyJSON => (
+  {
+    ...arrayProperty,
+    path: [arrayProperty.path, index].join(DELIMITER),
+    label: `[${index + 1}]`,
+    isArray: false,
+  }
+)

--- a/src/frontend/components/property-type/array/edit.spec.tsx
+++ b/src/frontend/components/property-type/array/edit.spec.tsx
@@ -31,6 +31,7 @@ describe('<PropertyType.Array.Edit />', function () {
         ItemComponent={ItemComponent as unknown as typeof React.Component}
         onChange={onChange}
         testId="some-test-id"
+        filter={{}}
         resource={{} as ResourceJSON}
       />
     </TestContextProvider>,

--- a/src/frontend/components/property-type/array/edit.tsx
+++ b/src/frontend/components/property-type/array/edit.tsx
@@ -1,37 +1,26 @@
 import React, { MouseEvent, useCallback } from 'react'
 import { Button, Section, FormGroup, FormMessage, Icon, Box } from '@admin-bro/design-system'
 
-import { RecordJSON } from '../../../interfaces'
 import AddNewItemButton from './add-new-item-translation'
 import { flat } from '../../../../utils'
-import { EditPropertyProps } from '../base-property-props'
+import { EditPropertyPropsInArray } from '../base-property-props'
 import { PropertyLabel } from '../utils/property-label'
+import { convertToSubProperty } from './convert-to-sub-property'
+import { PropertyJSON } from '../../../interfaces'
+import { removeSubProperty } from './remove-sub-property'
 
-type EditProps = EditPropertyProps & {
-  onChange: (record: RecordJSON) => any;
-  ItemComponent: typeof React.Component;
-  testId: string;
-}
+type EditProps = Required<EditPropertyPropsInArray>
 
 type ItemRendererProps = {
-  i: number;
-  onDelete: (event: MouseEvent) => boolean;
+  onDelete: (event: MouseEvent, property: PropertyJSON) => boolean;
 }
 
 const ItemRenderer: React.FC<EditProps & ItemRendererProps> = (props) => {
-  const { ItemComponent, property, i, onDelete } = props
+  const { ItemComponent, property, onDelete } = props
   return (
-    <Box flex flexDirection="row" alignItems="center" data-testid={`array-item-${i}`}>
+    <Box flex flexDirection="row" alignItems="center" data-testid={property.path}>
       <Box flexGrow={1}>
-        <ItemComponent
-          {...props}
-          property={{
-            ...property,
-            path: `${property.path}.${i}`,
-            label: `[${i + 1}]`,
-            isArray: false,
-          }}
-        />
+        <ItemComponent {...props} />
       </Box>
       <Box flexShrink={0} ml="lg">
         <Button
@@ -40,7 +29,7 @@ const ItemRenderer: React.FC<EditProps & ItemRendererProps> = (props) => {
           data-testid="delete-item"
           type="button"
           size="icon"
-          onClick={(event): boolean => onDelete(event)}
+          onClick={(event): boolean => onDelete(event, property)}
           variant="danger"
         >
           <Icon icon="TrashCan" />
@@ -64,25 +53,26 @@ const InputsInSection: React.FC<EditProps> = (props) => {
     return false
   }, [record, onChange, property])
 
-  const removeItem = useCallback((i, event: MouseEvent): boolean => {
-    const newItems = [...items]
-    newItems.splice(i, 1)
-    onChange(property.path, newItems)
+  const removeItem = useCallback((event: MouseEvent, subProperty: PropertyJSON): boolean => {
+    const newRecord = removeSubProperty(record, subProperty.path)
+    onChange(newRecord)
     event.preventDefault()
     return false
   }, [record, onChange, property])
 
   return (
     <Section mt="xl">
-      {items.map((item, i) => (
-        <ItemRenderer
-          {...props}
-          // eslint-disable-next-line react/no-array-index-key
-          key={i}
-          i={i}
-          onDelete={(event): boolean => removeItem(i, event)}
-        />
-      ))}
+      {items.map((item, i) => {
+        const itemProperty = convertToSubProperty(props.property, i)
+        return (
+          <ItemRenderer
+            {...props}
+            property={itemProperty}
+            key={itemProperty.path}
+            onDelete={removeItem}
+          />
+        )
+      })}
       <Button onClick={addNew} type="button" rounded>
         <AddNewItemButton resource={resource} property={property} />
       </Button>
@@ -92,7 +82,7 @@ const InputsInSection: React.FC<EditProps> = (props) => {
 
 const Edit: React.FC<EditProps> = (props) => {
   const { property, record, testId } = props
-  const error = record.errors && record.errors[property.path]
+  const error = record.errors && record.errors[property.propertyPath]
 
   return (
     <FormGroup error={!!error} data-testid={testId}>

--- a/src/frontend/components/property-type/array/remove-sub-property.spec.ts
+++ b/src/frontend/components/property-type/array/remove-sub-property.spec.ts
@@ -1,0 +1,62 @@
+import { expect } from 'chai'
+import { RecordJSON } from '../../../interfaces'
+import { removeSubProperty } from './remove-sub-property'
+
+import factory from '../../spec/factory'
+
+describe('removeSubProperty', () => {
+  let record: RecordJSON
+  let populated1: RecordJSON
+  let populated2: RecordJSON
+
+  beforeEach(async () => {
+    populated1 = await factory.build<RecordJSON>('RecordJSON')
+    populated2 = await factory.build<RecordJSON>('RecordJSON')
+    record = await factory.build<RecordJSON>('RecordJSON', {
+      params: {
+        'property.0': 'val1',
+        'property.1': 'val2',
+        'property.2': 'val3',
+        'property.3.nested.0': 'val1',
+        'property.3.nested.1': 'val2',
+        'property.3.nested.2': 'val2',
+        'property.4': 'val3',
+        'notPopulated.0': 'val1',
+        'notPopulated.1': 'val2',
+      },
+      populated: {
+        'property.0': null,
+        'property.1': populated1,
+        'property.2.nested.1': populated2,
+      },
+    })
+  })
+
+  context('remove populated record', () => {
+    let updatedRecord: RecordJSON
+
+    beforeEach(() => {
+      updatedRecord = removeSubProperty(record, 'property.1')
+    })
+
+    it('removes selected, populated, property from params and adjusts the keys', () => {
+      expect(updatedRecord.params).to.deep.equal({
+        'property.0': 'val1',
+        'property.1': 'val3',
+        'property.2.nested.0': 'val1',
+        'property.2.nested.1': 'val2',
+        'property.2.nested.2': 'val2',
+        'property.3': 'val3',
+        'notPopulated.0': 'val1',
+        'notPopulated.1': 'val2',
+      })
+    })
+
+    it('removes populated, record, adjusts the keys and keep it unflatten', () => {
+      expect(updatedRecord.populated).to.deep.equal({
+        'property.0': null,
+        'property.1.nested.1': populated2,
+      })
+    })
+  })
+})

--- a/src/frontend/components/property-type/array/remove-sub-property.ts
+++ b/src/frontend/components/property-type/array/remove-sub-property.ts
@@ -1,0 +1,44 @@
+import { flat } from '../../../../utils'
+import { RecordJSON } from '../../../interfaces'
+
+/**
+ * Removes selected array item from given record. It performs following tasks:
+ * 1. removes array item from the array
+ * 2. reorders keys in new array item
+ * 3. if property has populated fields it also reorders them
+ * it uses {@link flat } module and its removePath method
+ *
+ * @param {RecordJSON} record
+ * @param {string}     subPropertyPath            which has to be removed. It has to be flattened
+ *                                                in notation, and ending with array index
+ * @private
+ * @hide
+ */
+export const removeSubProperty = (record: RecordJSON, subPropertyPath: string): RecordJSON => {
+  // by default populated is flatten just to the path level - object itself is not flatten. That is
+  // why we have to retrieve the original state. That is why we have to replace record.populated to
+  // from { 'some.nested.1.key': RecordJSON } to { 'some.nested.1.key': 'some.nested.1.key' },
+  // then remove keys, and refill back some.nested.1.key to the value from the original populated
+  // object.
+  const populatedKeyMap: Record<string, string> = Object.keys(record.populated).reduce(
+    (memo, propertyKey) => ({
+      ...memo,
+      [propertyKey]: propertyKey,
+    }),
+    {},
+  )
+
+  const newPopulatedKeyMap = flat.removePath(populatedKeyMap, subPropertyPath)
+  const newPopulated = Object.entries(newPopulatedKeyMap).reduce(
+    (memo, [newPropertyKey, oldPropertyKey]) => ({
+      ...memo,
+      [newPropertyKey]: oldPropertyKey && record.populated[oldPropertyKey?.toString()],
+    }), {},
+  )
+
+  return {
+    ...record,
+    params: flat.removePath(record.params, subPropertyPath),
+    populated: newPopulated,
+  }
+}

--- a/src/frontend/components/property-type/array/show.tsx
+++ b/src/frontend/components/property-type/array/show.tsx
@@ -3,6 +3,7 @@ import { Section, ValueGroup } from '@admin-bro/design-system'
 
 import { RecordJSON, PropertyJSON } from '../../../interfaces'
 import { flat } from '../../../../utils'
+import { convertToSubProperty } from './convert-to-sub-property'
 
 type Props = {
   property: PropertyJSON;
@@ -19,19 +20,16 @@ export default class Show extends React.PureComponent<Props> {
     return (
       <ValueGroup label={property.label}>
         <Section>
-          {items.map((item, i) => (
-            <ItemComponent
-              {...this.props}
-              // eslint-disable-next-line react/no-array-index-key
-              key={i}
-              property={{
-                ...property,
-                path: `${property.path}.${i}`,
-                label: `[${i + 1}]`,
-                isArray: false,
-              }}
-            />
-          ))}
+          {(items || []).map((item, i) => {
+            const itemProperty = convertToSubProperty(property, i)
+            return (
+              <ItemComponent
+                {...this.props}
+                key={itemProperty.path}
+                property={itemProperty}
+              />
+            )
+          })}
         </Section>
       </ValueGroup>
     )

--- a/src/frontend/components/property-type/base-property-props.ts
+++ b/src/frontend/components/property-type/base-property-props.ts
@@ -1,4 +1,6 @@
+import React from 'react'
 import { RecordJSON, ResourceJSON, PropertyJSON, PropertyPlace } from '../../interfaces'
+import { BasePropertyJSON } from '../../interfaces/property-json/property-json.interface'
 
 export type SelectRecord = {
   value: string;
@@ -73,6 +75,15 @@ export type BasePropertyProps = {
   where: PropertyPlace;
 }
 
+export type BasePropertyComponentProps = Omit<BasePropertyProps, 'property'> & {
+  property: BasePropertyJSON;
+}
+
+export type BasePropertyPropsExtended = BasePropertyProps & {
+  ItemComponent: typeof React.Component;
+  testId: string;
+}
+
 /**
  * Props which are passed to all your custom property components in filter
  *
@@ -108,6 +119,11 @@ export type EditPropertyProps = BasePropertyProps & {
    * Record JSON representation. Null for filter
    */
   record: RecordJSON;
+}
+
+export type EditPropertyPropsInArray = EditPropertyProps & {
+  ItemComponent: typeof React.Component;
+  testId: string;
 }
 
 /**

--- a/src/frontend/components/property-type/index.tsx
+++ b/src/frontend/components/property-type/index.tsx
@@ -14,8 +14,9 @@ import * as richtext from './richtext'
 import * as reference from './reference'
 import * as textarea from './textarea'
 import * as password from './password'
-import { BasePropertyProps } from './base-property-props'
+import { BasePropertyComponentProps } from './base-property-props'
 import { PropertyType } from '../../../backend/adapters/property/base-property'
+import { PropertyJSON } from '../../interfaces'
 
 let globalAny: any = {}
 
@@ -178,7 +179,7 @@ const types: Record<PropertyType, any> = {
  *
  * return (<Wrapper />)
  */
-class BasePropertyComponent extends React.Component<BasePropertyProps> {
+class BasePropertyComponent extends React.Component<BasePropertyComponentProps> {
   static DefaultType
 
   static Boolean
@@ -194,7 +195,15 @@ class BasePropertyComponent extends React.Component<BasePropertyProps> {
   static Password
 
   render(): ReactNode {
-    const { property, resource, record, filter, where, onChange } = this.props
+    const { property: baseProperty, resource, record, filter, where, onChange } = this.props
+
+    const property: PropertyJSON = {
+      ...baseProperty,
+      // we fill the path if it is not there. That is why all the actual Component Renderers are
+      // called with the path set to this root path. Next mixed and array components adds to this
+      // path either index (for array) or subProperty name.
+      path: (baseProperty as PropertyJSON).path || baseProperty.propertyPath,
+    }
 
     const testId = `property-${where}-${property.path}`
 
@@ -226,22 +235,24 @@ class BasePropertyComponent extends React.Component<BasePropertyProps> {
     const Array = ArrayType[where]
     const Mixed = MixedType[where]
 
-    if (property.isArray) {
+    if (baseProperty.isArray) {
       if (!Array) { return (<div />) }
       return (
         <Array
           {...this.props}
+          property={property}
           ItemComponent={BasePropertyComponent}
           testId={testId}
         />
       )
     }
 
-    if (property.type === 'mixed' && property.subProperties && property.subProperties.length) {
+    if (baseProperty.type === 'mixed') {
       if (!Mixed) { return (<div />) }
       return (
         <Mixed
           {...this.props}
+          property={property}
           ItemComponent={BasePropertyComponent}
           testId={testId}
         />

--- a/src/frontend/components/property-type/mixed/convert-to-sub-property.ts
+++ b/src/frontend/components/property-type/mixed/convert-to-sub-property.ts
@@ -1,0 +1,12 @@
+import { DELIMITER } from '../../../../utils/flat/constants'
+import { PropertyJSON, BasePropertyJSON } from '../../../interfaces'
+
+export function convertToSubProperty(
+  property: PropertyJSON,
+  subProperty: BasePropertyJSON,
+): PropertyJSON {
+  return {
+    ...subProperty,
+    path: [property.path, subProperty.name].join(DELIMITER),
+  }
+}

--- a/src/frontend/components/property-type/mixed/edit.tsx
+++ b/src/frontend/components/property-type/mixed/edit.tsx
@@ -3,6 +3,7 @@ import { Section, FormGroup, FormMessage } from '@admin-bro/design-system'
 
 import { EditPropertyProps } from '../base-property-props'
 import { PropertyLabel } from '../utils/property-label'
+import { convertToSubProperty } from './convert-to-sub-property'
 
 type Props = {
   ItemComponent: typeof React.Component;
@@ -15,13 +16,16 @@ const Edit: React.FC<Props & EditPropertyProps> = (props) => {
     <FormGroup error={!!error}>
       <PropertyLabel property={property} />
       <Section {...property.props}>
-        {property.subProperties.filter(subProperty => !subProperty.isId).map(subProperty => (
-          <ItemComponent
-            {...props}
-            key={subProperty.path}
-            property={subProperty}
-          />
-        ))}
+        {property.subProperties.filter(subProperty => !subProperty.isId).map((subProperty) => {
+          const subPropertyWithPath = convertToSubProperty(property, subProperty)
+          return (
+            <ItemComponent
+              {...props}
+              key={subPropertyWithPath.path}
+              property={subPropertyWithPath}
+            />
+          )
+        })}
       </Section>
       <FormMessage>{error && error.message}</FormMessage>
     </FormGroup>

--- a/src/frontend/components/property-type/mixed/list.tsx
+++ b/src/frontend/components/property-type/mixed/list.tsx
@@ -4,28 +4,30 @@ import { Label } from '@admin-bro/design-system'
 
 import ViewHelpers from '../../../../backend/utils/view-helpers/view-helpers'
 import { EditPropertyProps } from '../base-property-props'
+import { convertToSubProperty } from './convert-to-sub-property'
 
 interface Props {
   ItemComponent: typeof React.Component;
 }
 
-// TODO define ItemComponent interface
-
+// TODO: define ItemComponent interface
 export default class List extends React.PureComponent<Props & EditPropertyProps> {
   renderItems(): React.ReactChild {
     const { property, ItemComponent } = this.props
     return (
       <React.Fragment>
-        {property.subProperties.filter(subProperty => !subProperty.isId).map(subProperty => (
-          <div key={subProperty.path}>
-            <Label inline>{`${subProperty.label}: `}</Label>
-            <ItemComponent
-              {...this.props}
-              key={subProperty.path}
-              property={{ ...subProperty }}
-            />
-          </div>
-        ))}
+        {property.subProperties.filter(subProperty => !subProperty.isId).map((subProperty) => {
+          const subPropertyWithPath = convertToSubProperty(property, subProperty)
+          return (
+            <div key={subPropertyWithPath.path}>
+              <Label inline>{`${subProperty.label}: `}</Label>
+              <ItemComponent
+                {...this.props}
+                property={subPropertyWithPath}
+              />
+            </div>
+          )
+        })}
       </React.Fragment>
     )
   }
@@ -34,7 +36,7 @@ export default class List extends React.PureComponent<Props & EditPropertyProps>
     const { property, record, resource } = this.props
     const showAction = record.recordActions.find(a => a.name === 'show')
 
-    if (resource.titleProperty.path === property.path && showAction) {
+    if (resource.titleProperty.propertyPath === property.propertyPath && showAction) {
       const h = new ViewHelpers()
       const href = h.recordActionUrl({
         resourceId: resource.id, recordId: record.id, actionName: 'show',

--- a/src/frontend/components/property-type/mixed/show.tsx
+++ b/src/frontend/components/property-type/mixed/show.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Section, ValueGroup } from '@admin-bro/design-system'
 
 import { BasePropertyProps } from '../base-property-props'
+import { convertToSubProperty } from './convert-to-sub-property'
 
 interface Props {
   ItemComponent: typeof React.Component;
@@ -12,13 +13,16 @@ const Show: React.FC<Props & BasePropertyProps> = (props) => {
   return (
     <ValueGroup label={property.label}>
       <Section>
-        {property.subProperties.filter(subProperty => !subProperty.isId).map(subProperty => (
-          <ItemComponent
-            {...props}
-            key={subProperty.path}
-            property={subProperty}
-          />
-        ))}
+        {property.subProperties.filter(subProperty => !subProperty.isId).map((subProperty) => {
+          const subPropertyWithPath = convertToSubProperty(property, subProperty)
+          return (
+            <ItemComponent
+              {...props}
+              key={subPropertyWithPath.path}
+              property={subPropertyWithPath}
+            />
+          )
+        })}
       </Section>
     </ValueGroup>
   )

--- a/src/frontend/components/spec/property-json.factory.ts
+++ b/src/frontend/components/spec/property-json.factory.ts
@@ -19,6 +19,7 @@ factory.define<PropertyJSON>('PropertyJSON', Object, {
   isRequired: true,
   components: undefined,
   path: factory.sequence('JSONProperty.path', n => `someProperty${n}`),
+  propertyPath: factory.sequence('JSONProperty.propertyPath', n => `someProperty${n}`),
   resourceId: 'someResourceId',
   isVirtual: false,
   props: {},

--- a/src/frontend/hooks/use-record/filter-record.ts
+++ b/src/frontend/hooks/use-record/filter-record.ts
@@ -9,7 +9,7 @@ export const filterRecordParams = function<T extends RecordJSON> (
   if (options.includeParams && record) {
     return {
       ...record,
-      params: flat.selectParams(record.params || {}, ...options.includeParams),
+      params: flat.selectParams(record.params || {}, options.includeParams),
     }
   }
   return record

--- a/src/frontend/interfaces/index.ts
+++ b/src/frontend/interfaces/index.ts
@@ -1,5 +1,5 @@
 export * from './action'
 export * from './page-json.interface'
-export * from './property-json.interface'
+export * from './property-json'
 export * from './record-json.interface'
 export * from './resource-json.interface'

--- a/src/frontend/interfaces/property-json/index.ts
+++ b/src/frontend/interfaces/property-json/index.ts
@@ -1,0 +1,1 @@
+export * from './property-json.interface'

--- a/src/frontend/interfaces/property-json/property-json.interface.ts
+++ b/src/frontend/interfaces/property-json/property-json.interface.ts
@@ -1,4 +1,4 @@
-import { PropertyType } from '../../backend/adapters/property/base-property'
+import { PropertyType } from '../../../backend/adapters/property/base-property'
 
 export type PropertyPlace = 'show' | 'list' | 'edit' | 'filter';
 
@@ -29,12 +29,16 @@ export interface PropertyJSON {
   availableValues: Array<{label: string; value: string}> | null;
   /**
    * Property uniq name
-   * @deprecated in version 3.3 in favour of `path`
    */
   name: string;
   /**
    * Property uniq path. For top level properties - the same as name, but for nested
    * properties it is separated with dot notation: `nested.property`
+   */
+  propertyPath: string;
+  /**
+   * Path of the actual value inside the record. It is usually the same as propertyPath, with the
+   * exception of array values.
    */
   path: string;
   /**
@@ -58,7 +62,7 @@ export interface PropertyJSON {
    * Contain list of all sub properties.
    * This is the case for nested schemas in MongoDB.
    */
-  subProperties: Array<PropertyJSON>;
+  subProperties: Array<BasePropertyJSON>;
   /**
    * All component names overridden by the user in PropertyOptions
    */
@@ -110,3 +114,10 @@ export interface PropertyJSON {
    */
   isVirtual: boolean;
 }
+
+/**
+ * Property without the path
+ *
+ * @memberof PropertyJSON
+ */
+export type BasePropertyJSON = Omit<PropertyJSON, 'path'>

--- a/src/frontend/interfaces/record-json.interface.ts
+++ b/src/frontend/interfaces/record-json.interface.ts
@@ -22,7 +22,7 @@ export interface RecordJSON {
   /**
    * If the record has properties which are references - here there will be populated records
    */
-  populated: Record<string, RecordJSON>;
+  populated: Record<string, RecordJSON | null | undefined>;
   /**
    * List of all validation errors
    */

--- a/src/frontend/interfaces/resource-json.interface.ts
+++ b/src/frontend/interfaces/resource-json.interface.ts
@@ -1,5 +1,6 @@
-import { PropertyJSON } from './property-json.interface'
+import { BasePropertyJSON } from './property-json'
 import { ActionJSON } from './action/action-json.interface'
+
 
 /**
  * Resource object accessible on the fronted
@@ -36,7 +37,7 @@ export interface ResourceJSON {
   /**
    * Property which should be treated as a Main property
    */
-  titleProperty: PropertyJSON;
+  titleProperty: BasePropertyJSON;
   /**
    * Actions available for entire resource with type: resource
    */
@@ -48,22 +49,22 @@ export interface ResourceJSON {
   /**
    * Properties which should be visible on the list
    */
-  listProperties: Array<PropertyJSON>;
+  listProperties: Array<BasePropertyJSON>;
   /**
    * Properties which should be visible on the edit view
    */
-  editProperties: Array<PropertyJSON>;
+  editProperties: Array<BasePropertyJSON>;
   /**
    * Properties which should be visible on the show view
    */
-  showProperties: Array<PropertyJSON>;
+  showProperties: Array<BasePropertyJSON>;
   /**
    * Properties which should be visible on the filter
    */
-  filterProperties: Array<PropertyJSON>;
+  filterProperties: Array<BasePropertyJSON>;
   /**
    * Map of all properties inside the resource. It also contains nested properties.
    * So this is the easies way of getting any property you like from a resource.
    */
-  properties: Record<string, PropertyJSON>;
+  properties: Record<string, BasePropertyJSON>;
 }

--- a/src/utils/flat/flat-module.ts
+++ b/src/utils/flat/flat-module.ts
@@ -7,6 +7,7 @@ import { set } from './set'
 import { get } from './get'
 import { merge } from './merge'
 import { pathToParts } from './path-to-parts'
+import { removePath } from './remove-path'
 
 export type FlatModuleType = {
   flatten: typeof flatten;
@@ -17,6 +18,7 @@ export type FlatModuleType = {
   filterOutParams: typeof filterOutParams;
   DELIMITER: typeof DELIMITER;
   pathToParts: typeof pathToParts;
+  removePath: typeof removePath;
   merge: typeof merge;
 }
 
@@ -42,6 +44,7 @@ export const flat: FlatModuleType = {
   get,
   selectParams,
   filterOutParams,
+  removePath,
   DELIMITER,
   pathToParts,
   merge,

--- a/src/utils/flat/flat.types.ts
+++ b/src/utils/flat/flat.types.ts
@@ -11,6 +11,19 @@ export type FlattenParams = {
 export type FlattenValue = string | boolean | number | Date | null | [] | {} | File
 
 /**
+ * @memberof flat
+ * @alias GetOptions
+ */
+export type GetOptions = {
+  /**
+   * Indicates if all the "less related" siblings should be included. This option takes care of
+   * fetching elements in nested arrays. Let's say you have keys: `nested.0.array.0` and `
+   * `nested.1.array.0.`. With `includeAllSiblings` you will fetch all nested.N.array elements.
+   */
+  includeAllSiblings?: boolean;
+}
+
+/**
  * Available types for flatten values. This is an Union of types:
  * - `string`
  * - `boolean`

--- a/src/utils/flat/get.spec.ts
+++ b/src/utils/flat/get.spec.ts
@@ -21,6 +21,10 @@ describe('module:flat.get', () => {
       nulled: null,
       emptyArray: [],
       emptyObject: {},
+      'nested.0.el.0.value': 'val0.0',
+      'nested.0.el.1.value': 'val0.1',
+      'nested.1.el.0.value': 'val1',
+      'nested.1.el.1.value': 'val2',
     }
   })
 
@@ -62,5 +66,43 @@ describe('module:flat.get', () => {
 
   it('returns null for null values', () => {
     expect(get(params, 'nulled')).to.eq(null)
+  })
+
+  it('returns nested arrays', () => {
+    expect(get(params, 'nested.0.el')).to.deep.equal([
+      { value: 'val0.0' },
+      { value: 'val0.1' },
+    ])
+  })
+
+  it('returns nested arrays with siblings when `includeAllSiblings` is set', () => {
+    expect(get(params, 'nested.el', { includeAllSiblings: true })).to.deep.equal([
+      { value: 'val0.0' },
+      { value: 'val0.1' },
+      { value: 'val1' },
+      { value: 'val2' },
+    ])
+  })
+
+  context('gets nested reference id', () => {
+    const referenceId = '5f7462621eb3495ea0f0edd9'
+
+    beforeEach(() => {
+      params = {
+        'Skills._id': '5f925f58016eab056c8c35a7',
+        'Skills.softShills': [],
+        'Skills.hardSkills.0._id': '5f925f58016eab056c8c35a8',
+        'Skills.hardSkills.0.name': '123',
+        'Skills.hardSkills.0.level': 'junior',
+        'Skills.hardSkills.0.Profession': referenceId,
+      }
+    })
+
+    it('returns referenceId when propertyPath is given', () => {
+      const propertyPath = 'Skills.hardSkills.Profession'
+      expect(get(params, propertyPath, { includeAllSiblings: true })).to.deep.equal(
+        [referenceId],
+      )
+    })
   })
 })

--- a/src/utils/flat/get.ts
+++ b/src/utils/flat/get.ts
@@ -3,6 +3,7 @@ import { DELIMITER } from './constants'
 import { selectParams } from './select-params'
 import { FlattenParams } from '../flat'
 import { propertyKeyRegex } from './property-key-regex'
+import { GetOptions } from './flat.types'
 
 const TEMP_HOLDING_KEY = 'TEMP_HOLDING_KEY'
 
@@ -11,11 +12,12 @@ const TEMP_HOLDING_KEY = 'TEMP_HOLDING_KEY'
  * @memberof flat
  * @param {FlattenParams}   params      flatten params from which property has to be taken
  * @param {string}          [propertyPath]  name of the property
+ * @param {GetOptions}      options     options
  * @returns {any}                       when property key exists directly it returns what is inside,
  *                                      otherwise it tries to find any nested objects and returns
  *                                      them
  */
-const get = (params: FlattenParams = {}, propertyPath?: string): any => {
+const get = (params: FlattenParams = {}, propertyPath?: string, options?: GetOptions): any => {
   if (!propertyPath) {
     return unflatten(params)
   }
@@ -27,13 +29,37 @@ const get = (params: FlattenParams = {}, propertyPath?: string): any => {
     return params[propertyPath]
   }
 
-  const regex = propertyKeyRegex(propertyPath)
-  const selectedParams = selectParams(params, propertyPath)
+  const regex = propertyKeyRegex(propertyPath, options)
+  const selectedParams = selectParams(params, propertyPath, options)
 
-  const nestedProperties = Object.keys(selectedParams).reduce((memo, key) => ({
-    ...memo,
-    [key.replace(regex, `${TEMP_HOLDING_KEY}${DELIMITER}`)]: selectedParams[key],
-  }), {} as FlattenParams)
+  const nestedProperties = Object.keys(selectedParams).reduce((memo, key, index) => {
+    let newKey = key.replace(regex, `${TEMP_HOLDING_KEY}${DELIMITER}`)
+
+    // when user wants to take allSiblings we have to fix the indexes so nested items from
+    // different siblings don't overlap
+    //
+    // Example for key `nested.1.el`:
+    //  'nested.0.el.0.value': 'val0.0',
+    //  'nested.0.el.1.value': 'val0.1',
+    //  'nested.1.el.0.value': 'val1',
+    //  'nested.1.el.1.value': 'val2',
+    //
+    // has to be changed to:
+    //  'TEMP_HOLDING_KEY.0.value': 'val0.0',
+    //  'TEMP_HOLDING_KEY.1.value': 'val0.1',
+    //  'TEMP_HOLDING_KEY.2.value': 'val1',
+    //  'TEMP_HOLDING_KEY.3.value': 'val2',
+    if (options?.includeAllSiblings) {
+      newKey = newKey.replace(
+        new RegExp(`${TEMP_HOLDING_KEY}\\${DELIMITER}(\\d+)`),
+        `${TEMP_HOLDING_KEY}.${index}`,
+      )
+    }
+    return {
+      ...memo,
+      [newKey]: selectedParams[key],
+    }
+  }, {} as FlattenParams)
 
   if (Object.keys(nestedProperties).length) {
     return (unflatten(nestedProperties) as {})[TEMP_HOLDING_KEY]

--- a/src/utils/flat/property-key-regex.ts
+++ b/src/utils/flat/property-key-regex.ts
@@ -1,7 +1,16 @@
 import { DELIMITER } from './constants'
+import { GetOptions } from './flat.types'
 // this is the regex used to find all existing properties starting with a key
 
-export const propertyKeyRegex = (property: string): RegExp => {
+export const propertyKeyRegex = (propertyPath: string, options?: GetOptions): RegExp => {
+  const delimiter = new RegExp(`\\${DELIMITER}`, 'g')
   const escapedDelimiter = `\\${DELIMITER}`
-  return new RegExp(`^${property.replace(DELIMITER, escapedDelimiter)}($|${escapedDelimiter})`)
+  // but for `nested.1.property.0` it will produce `nested(\.|\.\d+\.)1(\.|\.\d+\.)property.0`
+  // and this is intentional because user can give an one index in property path for with deeply
+  // nested arrays
+  const escapedDelimiterOrIndex = `(${escapedDelimiter}|${escapedDelimiter}\\d+${escapedDelimiter})`
+  const path = options?.includeAllSiblings
+    ? propertyPath.replace(delimiter, escapedDelimiterOrIndex)
+    : propertyPath.replace(delimiter, escapedDelimiter)
+  return new RegExp(`^${path}($|${escapedDelimiter})`, '')
 }

--- a/src/utils/flat/remove-path.doc.md
+++ b/src/utils/flat/remove-path.doc.md
@@ -1,0 +1,56 @@
+This method removes the given path from the flatten object.
+
+Most of the time removing one path is a trivial thing but when it comes to arrays it is more
+complicated than just simply removing its key.
+
+
+### Usage
+
+```javascript
+
+import { flat } from 'admin-bro'
+
+// do something with flat.removePath
+const paramsWithoutName = flat.removePath(otherParams, 'name.0')
+```
+
+### Why it exists?
+
+Take a look at this example:
+
+having the flatten object
+
+```javascript
+{
+  'property.0': 'val1',
+  'property.1': 'val2',
+  'property.2': 'val3',
+}
+```
+
+you want to remove `property.1` path. In order to do this you will need to remove key `property.1`
+and rename `property.2` to `property.1`
+
+and take a look at this example:
+
+```javascript
+{
+  name: 'value',
+  'notPopulated.0': 'val1',
+  'notPopulated.1': 'val2',
+  'property.0': 'val1',
+  'property.1': 'val2',
+  'property.2': 'val3',
+  'property.3.nested.0': 'val1',
+  'property.3.nested.1': 'val2',
+  'property.3.nested.2': 'val3',
+  'property.3.nested.3.some': 'val3',
+  'property.3.nested.4.some-other': 'val41',
+  'property.4': 'val4',
+  'property.5.nested.0': 'val5',
+}
+```
+
+what should happen when you want to remove `property.3.nested.3.some` ?
+
+This function solves these problems for you.

--- a/src/utils/flat/remove-path.spec.ts
+++ b/src/utils/flat/remove-path.spec.ts
@@ -1,0 +1,86 @@
+import { expect } from 'chai'
+import { removePath } from './remove-path'
+
+describe('removePath', () => {
+  let params
+
+  beforeEach(() => {
+    params = {
+      name: 'value',
+      'notPopulated.0': 'val1',
+      'notPopulated.1': 'val2',
+      'property.0': 'val1',
+      'property.1': 'val2',
+      'property.2': 'val3',
+      'property.3.nested.0': 'val1',
+      'property.3.nested.1': 'val2',
+      'property.3.nested.2': 'val3',
+      'property.3.nested.3.some': 'val3',
+      'property.3.nested.4.some-other': 'val41',
+      'property.4': 'val4',
+      'property.5.nested.0': 'val5',
+    }
+  })
+
+  it('removes regular property', () => {
+    expect(removePath(params, 'name')).not.to.have.keys('name')
+  })
+
+  it('removes element from the array and updates other indexes', () => {
+    const newParams = removePath(params, 'property.1')
+
+    expect(newParams).to.deep.equal({
+      name: 'value',
+      'notPopulated.0': 'val1',
+      'notPopulated.1': 'val2',
+      'property.0': 'val1',
+      'property.1': 'val3',
+      'property.2.nested.0': 'val1',
+      'property.2.nested.1': 'val2',
+      'property.2.nested.2': 'val3',
+      'property.2.nested.3.some': 'val3',
+      'property.2.nested.4.some-other': 'val41',
+      'property.3': 'val4',
+      'property.4.nested.0': 'val5',
+    })
+  })
+
+  it('removes parent element from the array and updates other indexes', () => {
+    const newParams = removePath(params, 'property.3.nested.3.some')
+
+    expect(newParams).to.deep.equal({
+      name: 'value',
+      'notPopulated.0': 'val1',
+      'notPopulated.1': 'val2',
+      'property.0': 'val1',
+      'property.1': 'val2',
+      'property.2': 'val3',
+      'property.3.nested.0': 'val1',
+      'property.3.nested.1': 'val2',
+      'property.3.nested.2': 'val3',
+      'property.3.nested.3.some-other': 'val41',
+      'property.4': 'val4',
+      'property.5.nested.0': 'val5',
+    })
+  })
+
+  it('leaves empty array when removing last element', () => {
+    let newParams = removePath(params, 'notPopulated.0')
+    newParams = removePath(newParams, 'notPopulated.0')
+
+    expect(newParams).to.deep.equal({
+      name: 'value',
+      notPopulated: [],
+      'property.0': 'val1',
+      'property.1': 'val2',
+      'property.2': 'val3',
+      'property.3.nested.0': 'val1',
+      'property.3.nested.1': 'val2',
+      'property.3.nested.2': 'val3',
+      'property.3.nested.3.some': 'val3',
+      'property.3.nested.4.some-other': 'val41',
+      'property.4': 'val4',
+      'property.5.nested.0': 'val5',
+    })
+  })
+})

--- a/src/utils/flat/remove-path.ts
+++ b/src/utils/flat/remove-path.ts
@@ -1,0 +1,40 @@
+import { filterOutParams } from './filter-out-params'
+import { FlattenParams } from './flat.types'
+import { get } from './get'
+import { set } from './set'
+import { pathToParts } from './path-to-parts'
+import { DELIMITER } from './constants'
+
+/**
+ * @load ./remove-path.doc.md
+ * @memberof flat
+ * @param {FlattenParams} params
+ * @param {...string} properties
+ * @returns {FlattenParams}
+ */
+export const removePath = (params: FlattenParams, path: string): FlattenParams => {
+  // by default simply filter out elements from the object
+  let filtered = filterOutParams(params, path)
+
+  // reverse means that we iterate from the closes parent
+  const parentPaths = pathToParts(path).reverse()
+
+  // but if one of the parent is an array
+  parentPaths.find((parentPath, parentIndex) => {
+    const parent = get(params, parentPath)
+    if (Array.isArray(parent)) {
+      // previous element is stringified index like 'property.1'
+      const previousPaths = parentPaths[parentIndex - 1].split(DELIMITER)
+      // so this is the index: 1
+      const previousPathIndex = previousPaths[previousPaths.length - 1]
+      parent.splice(+previousPathIndex, 1)
+      filtered = set(params, parentPath, parent)
+      // this works just for the firstly found array item, because in case of removing the last one
+      // it leaves `[]` as a value.
+      return true
+    }
+    return false
+  })
+
+  return filtered
+}

--- a/src/utils/flat/select-params.spec.ts
+++ b/src/utils/flat/select-params.spec.ts
@@ -31,14 +31,14 @@ describe('selectParams', () => {
   })
 
   it('returns multiple properties when they are given', () => {
-    expect(selectParams(params, 'name', 'surname')).to.deep.equal({
+    expect(selectParams(params, ['name', 'surname'])).to.deep.equal({
       name: 'John',
       surname: 'Doe',
     })
   })
 
   it('does not one property when is empty for multi-properties', () => {
-    expect(selectParams(params, 'name', 'surname', 'meta', 'empty')).to.deep.equal({
+    expect(selectParams(params, ['name', 'surname', 'meta', 'empty'])).to.deep.equal({
       name: 'John',
       surname: 'Doe',
       'meta.description': 'very ugly',

--- a/src/utils/flat/select-params.ts
+++ b/src/utils/flat/select-params.ts
@@ -1,18 +1,24 @@
 import { propertyKeyRegex } from './property-key-regex'
-import { FlattenParams } from './flat.types'
+import { FlattenParams, GetOptions } from './flat.types'
 
 /**
  * @load ./select-params.doc.md
  * @memberof flat
  * @param {FlattenParams} params
- * @param {...string} properties
+ * @param {string | Array<string>} properties
+ * @param {GetOptions} [options]
  * @returns {FlattenParams}
  */
-const selectParams = (params: FlattenParams, ...properties: Array<string>): FlattenParams => (
-  properties.reduce((globalMemo, property) => {
-    const regex = propertyKeyRegex(property)
+const selectParams = (
+  params: FlattenParams,
+  properties: string | Array<string>,
+  options?: GetOptions,
+): FlattenParams => {
+  const propertyArray = Array.isArray(properties) ? properties : [properties]
+  const selected = propertyArray.reduce((globalMemo, propertyPath) => {
+    const regex = propertyKeyRegex(propertyPath, options)
     const filtered = Object.keys(params)
-      // filter all keys which starts with property
+      // filter all keys which starts with property path
       .filter(key => key.match(regex))
       .reduce((memo, key) => ({
         ...memo,
@@ -23,6 +29,7 @@ const selectParams = (params: FlattenParams, ...properties: Array<string>): Flat
       ...filtered,
     }
   }, {} as FlattenParams)
-)
+  return selected
+}
 
 export { selectParams }


### PR DESCRIPTION
This is the first part of the update. The second will be the population of nested arrays.

What was done:
* all 'old' `PropertyJSON` fields send from the backend now becomes `BasePropertyJSON`. 
* `BasePropertyJSON` is `Omit<PropertyJSON, 'path'>`
* both of them got new property: `propertyPath` (old path) which is the "class" path.

So we have 3 fields defining the property path: 
* `propertyPath` - "class" path which can be used in PropertyOptions: `path.to.my.property`
* `path` - real instance path, which can be used to access actual record: `path.to.my.0.property` (they differs when it comes to arrays)
* `name` - the last part of the path, used to compute one from the other.

So data which goes from the bacend doesn't have `path` but it is require in custom components. So... All the real path calculation is done in BasePropertyCompoent.

Firstly it assume that what it receives on the root level: `path` in `path.to.my.0.property` example is also the path. And then it starts iterating deeper. Both Array and Mixed property types extends this path when they get the property and it is done recursively.

The last problem was with removing items from the array because when we remove one element we have to adjust index of all other elements which was already there. And... adjust the index of the populated property. This was done by adding new flat helper: removePath



