### PR TITLE
Update edit-action.ts

### DIFF
--- a/src/backend/actions/edit/edit-action.ts
+++ b/src/backend/actions/edit/edit-action.ts
@@ -1,3 +1,4 @@
+import omit from 'lodash/omit';
 import { Action, RecordActionResponse } from '../action.interface'
 import NotFoundError from '../../utils/errors/not-found-error'
 import populator from '../../utils/populator/populator'
@@ -39,7 +40,7 @@ export const EditAction: Action<RecordActionResponse> = {
       return { record: record.toJSON(currentAdmin) }
     }
 
-    const newRecord = await record.update(request.payload)
+    const newRecord = await record.update(omit(request.payload, 'id'))
     const [populatedRecord] = await populator([newRecord])
 
     // eslint-disable-next-line no-param-reassign

--- a/src/backend/actions/edit/edit-action.ts
+++ b/src/backend/actions/edit/edit-action.ts
@@ -1,4 +1,4 @@
-import omit from 'lodash/omit';
+import omit from 'lodash/omit'
 import { Action, RecordActionResponse } from '../action.interface'
 import NotFoundError from '../../utils/errors/not-found-error'
 import populator from '../../utils/populator/populator'


### PR DESCRIPTION
When updating a record the libraries try to run an INSERT SQL command on an existing ID, so, since the record is an instance of himself we don't need to pass the id to the record.update(...newValues) function.