### PR TITLE
[Fix] Fix populating arrays of references

### DIFF
--- a/src/utils/flat/get.ts
+++ b/src/utils/flat/get.ts
@@ -51,8 +51,8 @@ const get = (params: FlattenParams = {}, propertyPath?: string, options?: GetOpt
     //  'TEMP_HOLDING_KEY.3.value': 'val2',
     if (options?.includeAllSiblings) {
       newKey = newKey.replace(
-        new RegExp(`${TEMP_HOLDING_KEY}${DELIMITER}`),
-        `${TEMP_HOLDING_KEY}.${index}`,
+        new RegExp(`${TEMP_HOLDING_KEY}\\${DELIMITER}(\\d*)`),
+        `${TEMP_HOLDING_KEY}${DELIMITER}${index}`,
       )
     }
 

--- a/src/utils/flat/get.ts
+++ b/src/utils/flat/get.ts
@@ -51,7 +51,7 @@ const get = (params: FlattenParams = {}, propertyPath?: string, options?: GetOpt
     //  'TEMP_HOLDING_KEY.3.value': 'val2',
     if (options?.includeAllSiblings) {
       newKey = newKey.replace(
-        new RegExp(`${TEMP_HOLDING_KEY}\\${DELIMITER}(\\d+)`),
+        new RegExp(`${TEMP_HOLDING_KEY}${DELIMITER}`),
         `${TEMP_HOLDING_KEY}.${index}`,
       )
     }


### PR DESCRIPTION
Fixes https://github.com/SoftwareBrothers/admin-bro/issues/695

This does fix the issue and I can confirm it now works with even more complex arrays, i. e. array of values and nested arrays of values and references (tested using mongoose adapter and https://github.com/SoftwareBrothers/admin-bro-example-app).

The problem was that the regex for selecting siblings expected the temp key to have an index after delimiter but it didn't.

Test schemas:

Thing
```
module.exports = mongoose.model('Thing', {
  name: String,
  users: [{
    role: String,
    userId: {
      type: mongoose.ObjectId,
      ref: 'User',
    },
  }],
  tests: [{
    xyz: String,
    nested: [new mongoose.Schema({ value: String, userId: { type: mongoose.ObjectId, ref: 'User' } })]
  }]
})
```

User
```
const mongoose = require('mongoose')
const { Schema } = mongoose
const EMAIL_REGEXP = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i;

const validateEmail = email => EMAIL_REGEXP.test(email);

const UserSchema = new Schema({
  email: {
    type: String,
    lowercase: true,
    trim: true,
    required: true,
    validate: [validateEmail, 'Please fill a valid email address']
  },
  auth: {
    password: {
      type: String,
      required: true,
    },
  },
}, { timestamps: true })

const User = mongoose.model('User', UserSchema)

module.exports = User
```

![image](https://user-images.githubusercontent.com/16668924/102887325-057f3b80-4457-11eb-8776-e5f232d3279d.png)
