### PR TITLE
feat: pass custom styles and scripts to login template

### DIFF
--- a/src/frontend/login-template.tsx
+++ b/src/frontend/login-template.tsx
@@ -41,6 +41,11 @@ const html = async (
   const assets = await getAssets(admin)
   const faviconTag = getFaviconFromBranding(branding)
 
+  const scripts = ((assets && assets.scripts) || [])
+    .map(s => `<script src="${s}"></script>`)
+  const styles = ((assets && assets.styles) || [])
+    .map(l => `<link rel="stylesheet" type="text/css" href="${l}">`)
+
   store.dispatch(initializeBranding(branding))
   store.dispatch(initializeAssets(assets))
   store.dispatch(initializeLocale(admin.locale))
@@ -86,12 +91,14 @@ const html = async (
       ${style}
       ${faviconTag}
       <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,700" type="text/css">
+      ${styles.join('\n')}
 
       <script src="${h.assetPath('global.bundle.js')}"></script>
       <script src="${h.assetPath('design-system.bundle.js')}"></script>
     </head>
     <body>
       <div id="app">${loginComponent}</div>
+      ${scripts.join('\n')}
     </body>
     </html>
   `


### PR DESCRIPTION
This pull request parses the scripts and styles arguments passed to the AdminBro constructor for display on the login page. This will allow basic style overrides using a custom stylesheet.

Would probably allow you to close the following issues:
https://github.com/SoftwareBrothers/admin-bro/issues/347
https://github.com/SoftwareBrothers/admin-bro/issues/531

To use custom styles on the login page:

```javascript
new AdminBro({
  assets: {
    styles: ['/some-stylesheet.css'],
  }
});
```