### PR TITLE
fix: remove resource.update() call in record.save()

### DIFF
--- a/src/backend/actions/new/new-action.ts
+++ b/src/backend/actions/new/new-action.ts
@@ -31,7 +31,7 @@ export const NewAction: Action<RecordActionResponse> = {
     if (request.method === 'post') {
       let record = await resource.build(request.payload ? request.payload : {})
 
-      record = await record.save()
+      record = await record.create()
       const [populatedRecord] = await populator([record])
 
       // eslint-disable-next-line no-param-reassign

--- a/src/backend/adapters/record/base-record.ts
+++ b/src/backend/adapters/record/base-record.ts
@@ -172,6 +172,30 @@ class BaseRecord {
     return this
   }
 
+  /**
+   * Creates the record in the database
+   *
+   * Practically it invokes
+   * {@link BaseResource#create}.
+   *
+   * When validation error occurs it stores that to {@link BaseResource#errors}
+   *
+   * @return {Promise<BaseRecord>}        given record (this)
+   */
+  async create(): Promise<BaseRecord> {
+    try {
+      const returnedParams = await this.resource.create(this.params)
+      this.storeParams(returnedParams)
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        this.errors = e.propertyErrors
+        return this
+      }
+      throw e
+    }
+    this.errors = {}
+    return this
+  }
 
   /**
    * Returns uniq id of the Record.


### PR DESCRIPTION
I've noticed the [`save`](https://github.com/SoftwareBrothers/admin-bro/blob/907d03c7ed8f01ca5027655599faabad5c0f6d8c/src/backend/adapters/record/base-record.ts#L155
) method on record is really only called when a record is being created via the [`new`](https://github.com/SoftwareBrothers/admin-bro/blob/907d03c7ed8f01ca5027655599faabad5c0f6d8c/src/backend/actions/new/new-action.ts#L34) handler.

The [`edit`](https://github.com/SoftwareBrothers/admin-bro/blob/907d03c7ed8f01ca5027655599faabad5c0f6d8c/src/backend/actions/edit/edit-action.ts#L42) handler instead calls `record.update()` directly.

Therefore I was wondering why the [check for id](https://github.com/SoftwareBrothers/admin-bro/blob/907d03c7ed8f01ca5027655599faabad5c0f6d8c/src/backend/adapters/record/base-record.ts#L158-L162
) in the save method to determine if we should call `resource.update` or `resource.create`

Similarly, the [`useRecord`](https://github.com/SoftwareBrothers/admin-bro/blob/907d03c7ed8f01ca5027655599faabad5c0f6d8c/src/frontend/hooks/use-record/use-record.tsx#L89-L98) hook checks the id field, and call `edit` or `new` action (depending on id existence)

Basically, from what I can tell, this line is never executed:
https://github.com/SoftwareBrothers/admin-bro/blob/907d03c7ed8f01ca5027655599faabad5c0f6d8c/src/backend/adapters/record/base-record.ts#L159

Unless I'm missing something?

The reason I'm looking at this is because I'm trying to solve for https://github.com/SoftwareBrothers/admin-bro/issues/544 and this is the first step towards it