### PR TITLE
[Fix] Add `ignore_params` search param handling to ignore old params in redirect URLs

### DIFF
--- a/src/frontend/components/actions/utils/append-force-refresh.spec.ts
+++ b/src/frontend/components/actions/utils/append-force-refresh.spec.ts
@@ -50,4 +50,12 @@ describe('appendForceRefresh', () => {
 
     expect(newUrl).to.equal('http://example.com/resources/Test?other_param=test2&refresh=true')
   })
+
+  it('should ignore old search params if `ignore_params=true` is contained in the new url', () => {
+    const oldUrl = 'http://example.com/resources/Test?ignore_params=true'
+
+    const newUrl = appendForceRefresh(oldUrl, 'old_param=test2')
+
+    expect(newUrl).to.equal('http://example.com/resources/Test?refresh=true')
+  })
 })

--- a/src/frontend/components/actions/utils/append-force-refresh.ts
+++ b/src/frontend/components/actions/utils/append-force-refresh.ts
@@ -1,4 +1,5 @@
 export const REFRESH_KEY = 'refresh'
+export const IGNORE_PARAMS_KEY = 'ignore_params'
 
 /**
  * Adds refresh=true to the url, which in turn should cause list to reload.
@@ -14,8 +15,9 @@ export const appendForceRefresh = (url: string, search?: string): string => {
     ? url.substring(searchParamsIdx + 1)
     : null
 
-  const oldParams = search ?? urlSearchParams ?? window.location.search
-  const newParams = new URLSearchParams(oldParams)
+  const oldParams = new URLSearchParams(search ?? urlSearchParams ?? window.location.search ?? '')
+  const shouldIgnoreOldParams = new URLSearchParams(urlSearchParams || '').get(IGNORE_PARAMS_KEY) === 'true'
+  const newParams = shouldIgnoreOldParams ? new URLSearchParams('') : new URLSearchParams(oldParams.toString())
 
   newParams.set(REFRESH_KEY, 'true')
 


### PR DESCRIPTION
This fixes an issue where, i. e.:
1. You are in a list view of resource `X` with filters applied.
2. You run a custom action with redirect to another resource (`Y`).
3. The action works, but filters from resource `X` are applied and the redirect results in error.

If you add `ignore_params=true` in your custom action's redirect search params, it will ignore old search params when redirecting in frontend:
```
  return {
    redirectUrl: h.resourceUrl({
      resourceId: resource._decorated
        ? resource._decorated.id()
        : resource.id(),
      search: '?ignore_params=true',
    }),
    record: context.record.toJSON(currentAdmin),
  };
```