### PR TITLE
[Fix] Fix an issue where `mixed` type would add an additional nesting layer

### DIFF
--- a/src/frontend/components/property-type/mixed/convert-to-sub-property.ts
+++ b/src/frontend/components/property-type/mixed/convert-to-sub-property.ts
@@ -5,8 +5,9 @@ export function convertToSubProperty(
   property: PropertyJSON,
   subProperty: BasePropertyJSON,
 ): PropertyJSON {
+  const [subPropertyPath] = subProperty.name.split(DELIMITER).slice(-1)
   return {
     ...subProperty,
-    path: [property.path, subProperty.name].join(DELIMITER),
+    path: [property.path, subPropertyPath].join(DELIMITER),
   }
 }


### PR DESCRIPTION
This looks to work, I tested it with Sequelize and Mongoose adapters using simple and complex nested schemas. `subProperty.name` contained a full path which caused it to be merged incorrectly when building record params.