### PR TITLE
fix: only treat records as new after submit if no errors

### DIFF
--- a/src/frontend/components/actions/new.tsx
+++ b/src/frontend/components/actions/new.tsx
@@ -37,7 +37,7 @@ const New: FC<ActionProps> = (props) => {
         history.push(appendForceRefresh(response.data.redirectUrl))
       }
       // if record has id === has been created
-      if (response.data.record.id) {
+      if (response.data.record.id && !Object.keys(response.data.record.errors).length) {
         handleChange({ params: {}, populated: {}, errors: {} } as RecordJSON)
       }
     })


### PR DESCRIPTION
Currently if an `id` field is specified on creation (new action), the returned record object also has the `id` field, and the code behaves as if the record was created – even when an error occured.

To try to determine if the object was indeed created, I am suggesting to add a check for errors. This would assume that the errors are triggered before creating the record. As if the record is created but the error triggered after, the expected behavior is unclear.

If a record has been created, but the error is triggered afterwards, this change would affect the current behavior. Currently the data on the form is being cleared, and it is possible to create a new record. Even though errors are returned, they are not shown. Whereas after this change, the form will keep the data and the errors will be shown. If the record was indeed created, as things stands, an [update will be attempted](https://github.com/SoftwareBrothers/admin-bro/pull/763).

Note that the current behavior of clearing the form and not showing the error is confusing at best, and wrong (as the record wasn't created, or was created but with errors).

In the general use case of a record with a primary key set, and no "after" action hooks defined, if any errors occured they are most likely related to the underlying adapter. Therefore this change shouldn't affect most admin-bro users.

This is part of trying to implement a solution for https://github.com/SoftwareBrothers/admin-bro/issues/544 

