### PR TITLE
feat: store previous page url in location state when navigating

### DIFF
--- a/src/frontend/interfaces/action/build-action-click-handler.ts
+++ b/src/frontend/interfaces/action/build-action-click-handler.ts
@@ -37,7 +37,7 @@ export const buildActionClickHandler = (
     if (actionHasComponent(action)) {
       callApi()
     } else if (href) {
-      push(href)
+      push(href, { previousPage: window.location.href })
     }
   }
 


### PR DESCRIPTION
History API doesn't update `document.referrer` so it's impossible to know what page user navigated from.
This change stores previous page link in `location.state`. In my specific use case I needed it to be able to get `list` action filters and pass them to another resource action.