### PR TITLE
fix: fix a bug where translations would be missing after logging in

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "babel-plugin-styled-components": "^1.11.1",
     "commander": "^5.1.0",
     "flat": "^4.1.0",
-    "i18next": "^19.1.0",
+    "i18next": "19.8.7",
     "lodash": "^4.17.11",
     "ora": "^4.0.2",
     "prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5737,10 +5737,10 @@ husky@^4.2.5:
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
 
-i18next@^19.1.0:
-  version "19.8.3"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.8.3.tgz#10df7222db8c23389b13bceb9ba67a5e20a0241e"
-  integrity sha512-eVrqAw2gGGYYJaJMYw4VM1FNFawLD4b84IsoTZMVXeWHaxAM2gyTa34j2Sip15UkBz/LrSxdFJj0Jhlrz7EvHA==
+i18next@19.8.7:
+  version "19.8.7"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.8.7.tgz#ef023e353974d1b1453e8b6331bd9fb7cba427df"
+  integrity sha512-ezo1gb7QO4OQ5gQCdZMUxopwQSoqpRp6whdEjm1grxMSmkGj1NJ+kYS0UQd4NnpPIVqsgqTQ2L2eqSQYQ+U3Fw==
   dependencies:
     "@babel/runtime" "^7.12.0"
 


### PR DESCRIPTION
This PR sets `i18next` to use fixed version `19.8.7`, more here: https://github.com/i18next/i18next/issues/1570
The change should later be reverted once the issue gets fixed in `i18next` or another solution is found.