### PR TITLE
feat: add navigation: false option to hide resource from nav bar

### DIFF
--- a/src/backend/decorators/resource/resource-decorator.spec.ts
+++ b/src/backend/decorators/resource/resource-decorator.spec.ts
@@ -60,7 +60,7 @@ describe('ResourceDecorator', function () {
   describe('#getNavigation', function () {
     it('returns custom name with icon when options were specified', function () {
       const options = {
-        navigation: { name: 'someName', icon: 'someIcon' },
+        navigation: { name: 'someName', icon: 'someIcon', show: true },
       }
       expect(
         new ResourceDecorator({ ...args, options }).getNavigation(),

--- a/src/backend/decorators/resource/resource-options.interface.ts
+++ b/src/backend/decorators/resource/resource-options.interface.ts
@@ -72,20 +72,24 @@ export interface ResourceOptions {
    */
   href?: HrefFunction | string;
   /**
-   * Navigation option saying under which resource should be nested in sidebar.
+   * Navigation option saying under which menu this resource should be nested in sidebar.
    * Default to the database name.
    *
    * You have couple of options:
-   * - when you give both name and icon - your resource will be nested under this menu.
-   * - when you set it to null - resource will be top level, but without the icon
-   * - finally you can set the icon but leave name as `null`. In such case resource will be
-   *   top level and it will have an icon.
+   * - when you set both navigation.name and navigation.icon this resource will be nested under
+   *   this menu.
+   * - when you set navigation.name or navigation to a string this resource will be nested under
+   *   this menu and the icon will come from the database type
+   * - when you set navigation.icon but leave navigation.name as `null` this resource will be top
+   *   level and it will have an icon.
+   * - when you set navigation to null this resource will be top level, but without the icon
+   * - when you set navigation to false this resource will be hidden in the navigation
    * @new In version 3.3
    */
   navigation?: {
     name?: string | null;
     icon?: string;
-  } | string | null;
+  } | string | boolean | null;
 
 
   /**

--- a/src/backend/decorators/resource/utils/get-navigation.spec.ts
+++ b/src/backend/decorators/resource/utils/get-navigation.spec.ts
@@ -26,6 +26,7 @@ describe('.getNavigation', () => {
     expect(getNavigation(resourceOptions, defaultDatabase)).to.deep.eq({
       icon: mappedIcon,
       name: databaseName,
+      show: true,
     })
   })
 
@@ -35,6 +36,16 @@ describe('.getNavigation', () => {
     expect(getNavigation(resourceOptions, defaultDatabase)).to.be.null
   })
 
+  it('returns show false when options are set to false', () => {
+    resourceOptions.navigation = false
+
+    expect(getNavigation(resourceOptions, defaultDatabase)).to.deep.eq({
+      name: null,
+      icon: '',
+      show: false,
+    })
+  })
+
   it('returns parent with a default icon when options was set as a string', () => {
     const parentName = 'my navigation name'
     resourceOptions.navigation = parentName
@@ -42,6 +53,7 @@ describe('.getNavigation', () => {
     expect(getNavigation(resourceOptions, defaultDatabase)).to.deep.eq({
       icon: mappedIcon,
       name: parentName,
+      show: true,
     })
   })
 
@@ -52,6 +64,7 @@ describe('.getNavigation', () => {
     expect(getNavigation(resourceOptions, defaultDatabase)).to.deep.eq({
       icon,
       name: null,
+      show: true,
     })
   })
 
@@ -62,6 +75,7 @@ describe('.getNavigation', () => {
     expect(getNavigation(resourceOptions, defaultDatabase)).to.deep.eq({
       icon,
       name: null,
+      show: true,
     })
   })
 })

--- a/src/backend/decorators/resource/utils/get-navigation.ts
+++ b/src/backend/decorators/resource/utils/get-navigation.ts
@@ -35,19 +35,29 @@ export const getNavigation = (
     ? options.navigation
     : options.parent
 
-  if (navigationOption === null) {
+  if (navigationOption === null || navigationOption === true) {
     return null
+  }
+
+  if (navigationOption === false) {
+    return {
+      name: null,
+      icon: '',
+      show: false,
+    }
   }
 
   if (navigationOption === undefined || typeof navigationOption === 'string') {
     return {
       name: navigationOption || database.databaseName(),
       icon: getIcon(database.databaseType()),
+      show: true,
     }
   }
   const { name, icon } = navigationOption
   return {
     name: name || null,
     icon: icon || getIcon(database.databaseType()),
+    show: true,
   }
 }

--- a/src/backend/utils/build-feature/build-feature.spec.ts
+++ b/src/backend/utils/build-feature/build-feature.spec.ts
@@ -82,4 +82,19 @@ describe('mergeResourceOptions', function () {
       },
     })
   })
+
+  it('merges falsey options', function () {
+    const existingOptions = {
+      navigation: {
+        name: 'db',
+      },
+    }
+    const newOptions = {
+      navigation: false,
+    }
+
+    expect(mergeResourceOptions(existingOptions, newOptions)).to.deep.eq({
+      navigation: false,
+    })
+  })
 })

--- a/src/backend/utils/build-feature/build-feature.ts
+++ b/src/backend/utils/build-feature/build-feature.ts
@@ -70,16 +70,16 @@ const mergeResourceOptions = (
   const options = { ...oldOptions }
 
   basicOptions.forEach((propName: string) => {
-    if (newOptions[propName]) {
+    if (propName in newOptions) {
       options[propName] = newOptions[propName]
     }
   })
 
   listOptions.forEach((propName: string) => {
-    if (newOptions[propName]) {
+    if (propName in newOptions) {
       const mergedOptions = [
-        ...(oldOptions && oldOptions[propName] ? oldOptions[propName] : []),
-        ...(newOptions && newOptions[propName] ? newOptions[propName] : []),
+        ...(oldOptions && (propName in oldOptions) ? oldOptions[propName] : []),
+        ...(newOptions && (propName in newOptions) ? newOptions[propName] : []),
       ]
 
       options[propName] = uniq(mergedOptions)

--- a/src/frontend/components/spec/resource-json.factory.ts
+++ b/src/frontend/components/spec/resource-json.factory.ts
@@ -10,6 +10,7 @@ factory.define<ResourceJSON>('ResourceJSON', Object, {
   navigation: {
     name: 'someName',
     icon: 'someIcon',
+    show: true,
   },
   actions: [],
   resourceActions: [],

--- a/src/frontend/hooks/use-navigation-resources.ts
+++ b/src/frontend/hooks/use-navigation-resources.ts
@@ -42,7 +42,8 @@ export function useNavigationResources(
 
   // grouping resources into parents
   const map = resources
-    .filter(res => res.href) // first filter out resource which are not visible
+    // first filter out resources which are not visible
+    .filter(res => res.href && res.navigation?.show !== false)
     .reduce((memo, resource) => {
       // in case resource has the same name as parent we namespace it wit "resource-""
       const key = resource.navigation?.name || ['resource', resource.name].join('-')

--- a/src/frontend/interfaces/resource-json.interface.ts
+++ b/src/frontend/interfaces/resource-json.interface.ts
@@ -32,6 +32,10 @@ export interface ResourceJSON {
      * Parent icon
      */
     icon: string;
+    /**
+     * Visibility
+     */
+    show: boolean;
   } | null;
 
   /**


### PR DESCRIPTION
Adds a new variant to the navigation option for resources to specify that a resource should not be visible in the nav bar on the side. Resources can still have actions and are still clickable from references in other resources.

Fixes #749

Example usage:
```
const adminBro = new AdminBro({
  resources: [
    {
      resource: InternalModel,
      options: {
        navigation: false
      }
    },
  ]
})
```

