### PR TITLE
feat: add support for additional text below the sidebar logo

### DIFF
--- a/src/adminjs-options.interface.ts
+++ b/src/adminjs-options.interface.ts
@@ -349,7 +349,10 @@ export type BrandingOptions = {
    * @new since 6.0.0
    */
   withMadeWithLove?: boolean;
-
+  /**
+   * Optional additional text below the logo/companyName.
+   */
+  additionalText?: string;
   /**
    * URL to a favicon
    */

--- a/src/frontend/components/app/sidebar/sidebar-branding.tsx
+++ b/src/frontend/components/app/sidebar/sidebar-branding.tsx
@@ -43,7 +43,7 @@ const h = new ViewHelpers()
 const SidebarBranding: React.FC<Props> = (props) => {
   const { branding } = props
   const { logo, companyName } = branding
-  return (
+  return <>
     <StyledLogo
       className={cssClass('Logo')}
       to={h.dashboardUrl()}
@@ -55,7 +55,10 @@ const SidebarBranding: React.FC<Props> = (props) => {
         />
       ) : <h1>{companyName}</h1>}
     </StyledLogo>
-  )
+    { branding.additionalText &&
+      <span>{branding.additionalText}</span>
+    }
+    </>;
 }
 
 export default allowOverride(SidebarBranding, 'SidebarBranding')


### PR DESCRIPTION
This allows us to specify which environment our application is on. It felt like a good idea to make this generic and upstream the work rather than making a custom component.